### PR TITLE
Remove trend filter integration

### DIFF
--- a/circuit_breaker.py
+++ b/circuit_breaker.py
@@ -1,0 +1,43 @@
+import logging
+
+
+class CircuitBreaker:
+    """
+    Stops trading if Daily Max Loss or Max Consecutive Losses are hit.
+    """
+
+    def __init__(self, max_daily_loss=500.0, max_consecutive_losses=3):
+        self.max_daily_loss = abs(max_daily_loss)
+        self.max_consecutive_losses = max_consecutive_losses
+
+        self.daily_pnl = 0.0
+        self.consecutive_losses = 0
+        self.is_tripped = False
+
+    def update_trade_result(self, pnl: float):
+        self.daily_pnl += pnl
+
+        if pnl < 0:
+            self.consecutive_losses += 1
+        else:
+            self.consecutive_losses = 0
+
+        # Check triggers
+        if self.daily_pnl <= -self.max_daily_loss:
+            self.is_tripped = True
+            logging.critical(f"🛑 CIRCUIT BREAKER: Max Daily Loss Hit (${self.daily_pnl:.2f})")
+
+        if self.consecutive_losses >= self.max_consecutive_losses:
+            self.is_tripped = True
+            logging.critical(f"🛑 CIRCUIT BREAKER: Max Consecutive Losses Hit ({self.consecutive_losses})")
+
+    def should_block_trade(self) -> tuple[bool, str]:
+        if self.is_tripped:
+            return True, "Circuit Breaker Tripped (Risk Limit Reached)"
+        return False, ""
+
+    def reset_daily(self):
+        self.daily_pnl = 0.0
+        self.consecutive_losses = 0
+        self.is_tripped = False
+        logging.info("🔄 Circuit Breaker reset for new day")

--- a/news_filter.py
+++ b/news_filter.py
@@ -1,0 +1,51 @@
+import datetime
+import logging
+
+import pytz
+
+
+class NewsFilter:
+    """
+    Blocks trading during specific time windows (e.g., High Impact News, Exchange Close).
+    """
+
+    def __init__(self):
+        self.et = pytz.timezone("America/New_York")
+        # Daily Recurrent Blackouts (Hour, Minute, Duration_Minutes)
+        # Example: CME Close/Reopen (16:55 - 18:05 ET)
+        self.daily_blackouts = [
+            (16, 55, 70),
+        ]
+        # Specific Event Blackouts (Year, Month, Day, Hour, Minute, Duration_Minutes)
+        self.calendar_blackouts = [
+            # Example: FOMC
+            # (2025, 12, 18, 14, 0, 30),
+        ]
+
+    def should_block_trade(self, current_time: datetime.datetime) -> tuple[bool, str]:
+        # Ensure time is ET
+        if current_time.tzinfo is None:
+            current_time = pytz.utc.localize(current_time).astimezone(self.et)
+        else:
+            current_time = current_time.astimezone(self.et)
+
+        # 1. Check Daily Recurring Blackouts
+        for hour, minute, duration in self.daily_blackouts:
+            start = current_time.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            end = start + datetime.timedelta(minutes=duration)
+
+            # Handle timeframe overlap if needed (simplified for intraday)
+            if start <= current_time <= end:
+                return True, f"Daily Blackout: {start.strftime('%H:%M')} - {end.strftime('%H:%M')}"
+
+        # 2. Check Specific Calendar Events
+        for year, month, day, h, m, duration in self.calendar_blackouts:
+            event_start = self.et.localize(datetime.datetime(year, month, day, h, m))
+            # Block 5 mins before event
+            block_start = event_start - datetime.timedelta(minutes=5)
+            block_end = event_start + datetime.timedelta(minutes=duration)
+
+            if block_start <= current_time <= block_end:
+                return True, f"News Event Blackout until {block_end.strftime('%H:%M')}"
+
+        return False, ""


### PR DESCRIPTION
## Summary
- remove the trend filter module and related import
- strip trend baseline checks from fast, standard, and loose strategy paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f39625e28832ab1133523914bbe48)