### PR TITLE
Fix SL minimum of 4 ticks to prevent trade rejections

### DIFF
--- a/dynamic_signal_engine.py
+++ b/dynamic_signal_engine.py
@@ -436,9 +436,11 @@ class DynamicSignalEngine:
                         signal = 'SHORT'
 
                 if signal:
+                    # Enforce minimum SL of 4 ticks (broker requirement)
+                    sl_value = max(4.0, float(strategy['Best_SL']))
                     signal_data = {
                         'signal': signal,
-                        'sl': float(strategy['Best_SL']),
+                        'sl': sl_value,
                         'tp': float(strategy['Best_TP']),
                         'opt_wr': float(strategy['Opt_WR']),
                         'timeframe': timeframe_str,


### PR DESCRIPTION
Enforce minimum stop loss of 4 ticks in DynamicSignalEngine since broker rejects orders with SL < 4 ticks. Some strategies in the database had Best_SL values of 2 or 3 which caused rejections.