### PR TITLE
Migrate from pytz to zoneinfo and fix contract search

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import Optional
-import pytz
+from zoneinfo import ZoneInfo
 
 
 # Core runtime configuration for the bot. This was pulled directly from the
@@ -156,9 +156,9 @@ def determine_current_contract_symbol(
     tz_name: str = "US/Eastern",
     today: Optional[datetime.date] = None,
 ) -> str:
-    """Return the MES contract symbol for the current date (e.g., CON.F.US.MES.Z25)."""
+    """Return the MES contract symbol for the current date (e.g., MESZ25)."""
 
-    tz = pytz.timezone(tz_name)
+    tz = ZoneInfo(tz_name.replace("US/Eastern", "America/New_York"))
     current_date = today or datetime.datetime.now(tz).date()
     month_code = CONTRACT_MONTH_CODES.get(current_date.month)
 
@@ -166,7 +166,9 @@ def determine_current_contract_symbol(
         raise ValueError(f"Unsupported month for contract mapping: {current_date.month}")
 
     year_code = str(current_date.year % 100).zfill(2)
-    return f"CON.F.US.{root}.{month_code}{year_code}"
+    # Return short identifier for matching (e.g., MES.Z25)
+    # Full contract ID format is CON.F.US.MES.Z25
+    return f"{root}.{month_code}{year_code}"
 
 
 def refresh_target_symbol():

--- a/confluence_strategy.py
+++ b/confluence_strategy.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, Optional
 
 import pandas as pd
-import pytz
+from zoneinfo import ZoneInfo
 
 from dynamic_sltp_params import dynamic_sltp_engine
 from strategy_base import Strategy
@@ -11,7 +11,7 @@ from strategy_base import Strategy
 
 class ConfluenceStrategy(Strategy):
     def __init__(self):
-        self.et = pytz.timezone('US/Eastern')
+        self.et = ZoneInfo('America/New_York')
         # Session tracking
         self.current_session = None
         self.prev_session_high = None

--- a/dynamic_signal_engine.py
+++ b/dynamic_signal_engine.py
@@ -10,7 +10,7 @@ Date: December 2025
 import logging
 from typing import Optional, Dict
 from datetime import datetime
-import pytz
+from zoneinfo import ZoneInfo
 
 
 # ============================================================================
@@ -266,7 +266,7 @@ class DynamicSignalEngine:
 
     def __init__(self):
         """Initialize the signal engine."""
-        self.et_tz = pytz.timezone('US/Eastern')
+        self.et_tz = ZoneInfo('America/New_York')
         self.strategies = STRATEGY_DATABASE
 
     def _log_initialization(self):

--- a/dynamic_sltp_params.py
+++ b/dynamic_sltp_params.py
@@ -10,7 +10,7 @@ Example key: "Q1_W2_FRI_NY_AM"
 Generated: 2025-12-10 11:04:38
 """
 
-import pytz
+from zoneinfo import ZoneInfo
 from typing import Dict
 import pandas as pd
 import numpy as np
@@ -2966,7 +2966,7 @@ class DynamicSLTPEngine:
     """
     
     def __init__(self):
-        self.et = pytz.timezone('US/Eastern')
+        self.et = ZoneInfo('America/New_York')
     
     @staticmethod
     def get_yearly_quarter(month: int) -> str:

--- a/monitor_ui.py
+++ b/monitor_ui.py
@@ -6,7 +6,7 @@ Displays real-time signals, positions, and market data without modifying the mai
 
 import requests
 import time
-import pytz
+from zoneinfo import ZoneInfo
 import re
 from datetime import datetime
 from pathlib import Path
@@ -147,7 +147,7 @@ class APIMonitor:
         self.base_url = CONFIG['REST_BASE_URL']
         self.account_id = None
         self.contract_id = None
-        self.et = pytz.timezone('US/Eastern')
+        self.et = ZoneInfo('America/New_York')
 
     def login(self):
         """Authenticate with the API"""
@@ -406,7 +406,7 @@ def main():
                 price = api_monitor.fetch_market_data()
                 if price:
                     # Determine session
-                    current_time = datetime.now(pytz.timezone('US/Eastern'))
+                    current_time = datetime.now(ZoneInfo('America/New_York'))
                     session = get_current_session(current_time)
 
                     ui.update_market_context({

--- a/news_filter.py
+++ b/news_filter.py
@@ -1,7 +1,8 @@
 import datetime
 import logging
+from datetime import timezone as dt_timezone
 
-import pytz
+from zoneinfo import ZoneInfo
 
 
 class NewsFilter:
@@ -10,7 +11,7 @@ class NewsFilter:
     """
 
     def __init__(self):
-        self.et = pytz.timezone("America/New_York")
+        self.et = ZoneInfo("America/New_York")
         # Daily Recurrent Blackouts (Hour, Minute, Duration_Minutes)
         # Example: CME Close/Reopen (16:55 - 18:05 ET)
         self.daily_blackouts = [
@@ -25,7 +26,7 @@ class NewsFilter:
     def should_block_trade(self, current_time: datetime.datetime) -> tuple[bool, str]:
         # Ensure time is ET
         if current_time.tzinfo is None:
-            current_time = pytz.utc.localize(current_time).astimezone(self.et)
+            current_time = current_time.replace(tzinfo=dt_timezone.utc).astimezone(self.et)
         else:
             current_time = current_time.astimezone(self.et)
 

--- a/regime_strategy.py
+++ b/regime_strategy.py
@@ -302,9 +302,9 @@ def get_strategy_stats() -> Dict:
 if __name__ == "__main__":
     # Test: Show current configuration
     from datetime import datetime
-    import pytz
-    
-    et = pytz.timezone('America/New_York')
+    from zoneinfo import ZoneInfo
+
+    et = ZoneInfo('America/New_York')
     now = datetime.now(et)
     
     combo = get_combo_key(now)

--- a/rejection_filter.py
+++ b/rejection_filter.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 from typing import Optional, Tuple
 
-import pytz
+from zoneinfo import ZoneInfo
+from datetime import timezone as dt_timezone
 
 from event_logger import event_logger
 
@@ -383,7 +384,7 @@ class RejectionFilter:
         """Backfill filter state from historical DataFrame (legacy method)."""
         logging.info("Backfilling rejection filter from historical data...")
         for _, row in df.iterrows():
-            ts = row['timestamp'].tz_localize(pytz.UTC).tz_convert(tz)
+            ts = row['timestamp'].tz_localize(dt_timezone.utc).tz_convert(tz)
             self.update(ts, row['high'], row['low'], row['close'])
 
         logging.info(f"✅ Backfill Complete.")

--- a/session_manager.py
+++ b/session_manager.py
@@ -2,11 +2,11 @@ import datetime
 import logging
 
 import joblib
-import pytz
+from zoneinfo import ZoneInfo
 
 from config import CONFIG
 
-NY_TZ = pytz.timezone('America/New_York')
+NY_TZ = ZoneInfo('America/New_York')
 
 
 class SessionManager:

--- a/volatility_filter.py
+++ b/volatility_filter.py
@@ -14,7 +14,7 @@ import pandas as pd
 import numpy as np
 import logging
 from typing import Dict, Tuple
-import pytz
+from zoneinfo import ZoneInfo
 
 # ============================================================
 # HIERARCHICAL VOLATILITY THRESHOLDS (320 combinations)
@@ -377,7 +377,7 @@ class HierarchicalVolatilityFilter:
         self.low_vol_stop_mult = low_vol_stop_mult
         self.low_vol_size_mult = low_vol_size_mult
         self.std_window = std_window
-        self.et = pytz.timezone('US/Eastern')
+        self.et = ZoneInfo('America/New_York')
         
         # Cache
         self._last_std = None


### PR DESCRIPTION
- Replace pytz with Python 3.9+ zoneinfo module to fix pkg_resources deprecation warning on Python 3.14
- Fix contract search to use root symbol (MES) for API search instead of full symbol, then match against short identifier (MES.Z25)
- Update TARGET_SYMBOL format from CON.F.US.MES.Z25 to MES.Z25 for proper contract ID matching