### PR TITLE
Remove DynamicEngine2 strategy from active use

### DIFF
--- a/TERMINAL_UI_README.md
+++ b/TERMINAL_UI_README.md
@@ -23,13 +23,12 @@ The JULIE Terminal UI is a **standalone monitoring application** that provides a
   - TP and SL distances
   - Execution status (EXECUTED, BLOCKED, PENDING)
   - Timestamp for each signal
-- **Strategy Coverage**: Monitors all 8 strategies:
+- **Strategy Coverage**: Monitors all 7 strategies:
   - RegimeAdaptive (FAST)
   - IntradayDip (FAST)
   - Confluence (STANDARD)
   - MLPhysics (STANDARD)
   - DynamicEngine (STANDARD)
-  - DynamicEngine2 (STANDARD)
   - ORB (LOOSE)
   - ICTModel (LOOSE)
 

--- a/config.py
+++ b/config.py
@@ -81,11 +81,6 @@ CONFIG = {
             "exit_if_not_green_by": 30,   # Give trade room to develop
             "max_profit_crosses": 4,      # Allow some chop
         },
-        "DynamicEngine2": {
-            "enabled": True,
-            "exit_if_not_green_by": 30,   # Give trade room to develop
-            "max_profit_crosses": 4,      # Allow some chop
-        },
         "ORB_Long": {"enabled": False},
     },
 

--- a/julie001.py
+++ b/julie001.py
@@ -28,7 +28,6 @@ from dynamic_chop import DynamicChopAnalyzer
 from ict_model_strategy import ICTModelStrategy
 from ml_physics_strategy import MLPhysicsStrategy
 from dynamic_engine_strategy import DynamicEngineStrategy
-from dynamic_engine2_strategy import DynamicEngine2Strategy
 from event_logger import event_logger
 from circuit_breaker import CircuitBreaker
 from news_filter import NewsFilter
@@ -1183,12 +1182,10 @@ def run_bot():
     # STANDARD PRIORITY - Normal execution
     ml_strategy = MLPhysicsStrategy()
     dynamic_engine_strat = DynamicEngineStrategy()
-    dynamic_engine2_strat = DynamicEngine2Strategy()
-    
+
     standard_strategies = [
         ConfluenceStrategy(),
         dynamic_engine_strat,
-        dynamic_engine2_strat,
     ]
     
     # Only add ML strategy if at least one model loaded successfully
@@ -1724,8 +1721,8 @@ def run_bot():
                                 else:
                                     event_logger.log_filter_check("ChopFilter", signal['side'], True)
 
-                            # Extension (Except DynamicEngine and DynamicEngine2)
-                            if signal['strategy'] not in ["DynamicEngine", "DynamicEngine2"]:
+                            # Extension (Except DynamicEngine)
+                            if signal['strategy'] not in ["DynamicEngine"]:
                                 ext_blocked, ext_reason = extension_filter.should_block_trade(signal['side'])
                                 if ext_blocked:
                                     event_logger.log_filter_check("ExtensionFilter", signal['side'], False, ext_reason)

--- a/monitor_ui.py
+++ b/monitor_ui.py
@@ -128,7 +128,7 @@ class LogMonitor:
         # Extract strategy signals before filters
         elif any(strat in line for strat in ["RegimeAdaptive", "IntradayDip", "Confluence", "ORB", "ICT", "MLPhysics", "DynamicEngine"]):
             if "signal" in line.lower():
-                for strategy in ["RegimeAdaptive", "IntradayDip", "Confluence", "ORB", "ICTModel", "MLPhysics", "DynamicEngine", "DynamicEngine2"]:
+                for strategy in ["RegimeAdaptive", "IntradayDip", "Confluence", "ORB", "ICTModel", "MLPhysics", "DynamicEngine"]:
                     if strategy in line:
                         # Try to extract side
                         side_match = re.search(r'(LONG|SHORT)', line)


### PR DESCRIPTION
- Remove import and instantiation in julie001.py
- Remove from standard_strategies list
- Remove from ExtensionFilter exemption
- Remove configuration from config.py
- Remove from monitor_ui.py monitoring
- Update TERMINAL_UI_README.md to reflect 7 strategies

Note: Strategy files (dynamic_engine2_strategy.py and dynamic_signal_engine2.py) are preserved in the repository.