### PR TITLE
Implement incremental data fetching for MES and MNQ history

### DIFF
--- a/smt_strategy.py
+++ b/smt_strategy.py
@@ -16,38 +16,74 @@ class SMTStrategy(Strategy):
         self.lookback_minutes = lookback_minutes
         self.analyzer = SMTAnalyzer()
 
+        # Internal storage for MNQ history
+        self.mnq_history = pd.DataFrame()
+        self.is_initialized = False
+
+    def _update_mnq_history(self) -> pd.DataFrame:
+        """Handles the incremental fetching logic for MNQ."""
+        try:
+            if not self.is_initialized:
+                # FIRST RUN: Fetch the massive 20k bar chunk
+                # We use 20000 to match the main bot, ensuring deep history for alignment
+                logging.info(f"SMTStrategy: Fetching initial MNQ history (Max)...")
+                new_data = self.mnq_client.get_market_data(lookback_minutes=20000, force_fetch=True)
+
+                if not new_data.empty:
+                    self.mnq_history = new_data
+                    self.is_initialized = True
+            else:
+                # SUBSEQUENT RUNS: Fetch only the last 15 minutes
+                new_data = self.mnq_client.get_market_data(lookback_minutes=15, force_fetch=True)
+
+                if not new_data.empty:
+                    # Combine and Deduplicate
+                    self.mnq_history = pd.concat([self.mnq_history, new_data])
+                    self.mnq_history = self.mnq_history[~self.mnq_history.index.duplicated(keep='last')]
+
+                    # Trim to keep memory usage reasonable (keep slightly more than lookback)
+                    # We keep 5000 bars to be safe for SMT calculations
+                    if len(self.mnq_history) > 5000:
+                        self.mnq_history = self.mnq_history.iloc[-5000:]
+
+            return self.mnq_history
+
+        except Exception as e:
+            logging.error(f"SMT Data Error: {e}")
+            return self.mnq_history
+
     def _prepare_df(self, df: pd.DataFrame) -> pd.DataFrame:
         if df.empty:
             return df
-        return df.rename(
-            columns={
-                "open": "Open",
-                "high": "High",
-                "low": "Low",
-                "close": "Close",
-                "volume": "Volume",
-            }
-        )
+        # Normalize column names to Capitalized (Open, High...) for Analyzer
+        cols = {c: c.capitalize() for c in ['open', 'high', 'low', 'close', 'volume'] if c in df.columns}
+        return df.rename(columns=cols)
 
     def on_bar(self, df_mes: pd.DataFrame) -> Optional[Dict]:
         if df_mes.empty:
             return None
 
-        # Fetch synchronized MNQ data using its dedicated client
-        df_mnq = self.mnq_client.get_market_data(
-            lookback_minutes=self.lookback_minutes
-        )
+        # 1. Get MNQ Data using our new incremental method
+        df_mnq = self._update_mnq_history()
+
         if df_mnq.empty:
-            logging.debug("SMTStrategy: MNQ data unavailable")
+            # logging.debug("SMTStrategy: MNQ data unavailable") # Reduce noise
             return None
 
         df_mnq_prepared = self._prepare_df(df_mnq)
         df_mes_prepared = self._prepare_df(df_mes)
 
-        if df_mnq_prepared.empty or df_mes_prepared.empty:
+        # 2. Sync Check: Ensure MNQ data isn't stale compared to MES
+        if df_mnq_prepared.index[-1] < df_mes_prepared.index[-1] - pd.Timedelta(minutes=5):
+            logging.warning("SMTStrategy: MNQ data is lagging MES data. Skipping signal.")
             return None
 
+        # 3. Run Analysis
         signals = self.analyzer.generate_signals(df_mnq_prepared, df_mes_prepared)
+
+        if signals.empty:
+            return None
+
         latest = signals["signal"].iloc[-1]
 
         if latest == 0:


### PR DESCRIPTION
## Summary
- initialize a master MES history buffer with a single large fetch at startup, then incrementally append recent data each loop while deduplicating and trimming
- update strategy loop to resample from the maintained master history and retain backfill behavior using locally cached bars
- refactor SMT strategy to maintain its own MNQ history with initial deep fetch, incremental 15-minute updates, deduplication, and stale-data safeguards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940dc484ca0832a9896b5b9a50f822c)