### PR TITLE
Remove pytz dependency in favor of zoneinfo

### DIFF
--- a/Rose.bat
+++ b/Rose.bat
@@ -22,7 +22,7 @@ call venv\Scripts\activate.bat
 echo.
 
 REM Step 3: Check if packages are installed
-python -c "import pandas, numpy, requests, pytz, joblib, sklearn, rich, colorama, click" 2>nul
+python -c "import pandas, numpy, requests, joblib, sklearn, rich, colorama, click" 2>nul
 if errorlevel 1 (
     echo [3] Upgrading pip...
     python -m pip install --upgrade pip
@@ -42,11 +42,7 @@ if errorlevel 1 (
     echo Installing requests...
     pip install requests
     echo.
-    
-    echo Installing pytz...
-    pip install pytz
-    echo.
-    
+
     echo Installing joblib...
     pip install joblib
     echo.

--- a/TERMINAL_UI_README.md
+++ b/TERMINAL_UI_README.md
@@ -83,7 +83,7 @@ Live scrolling log of bot activity:
 
 1. **Python packages** (should already be installed with your bot):
    ```bash
-   pip install rich requests pandas pytz
+   pip install rich requests pandas
    ```
 
 2. **Configuration**: Your `config.py` must have valid credentials:
@@ -283,7 +283,7 @@ python monitor_ui.py
 - `rich` - Terminal UI framework with live updates
 - `requests` - HTTP client for TopstepX API
 - `pandas` - Data processing (inherited from bot)
-- `pytz` - Timezone handling (US/Eastern)
+- `zoneinfo` - Timezone handling (US/Eastern) - built into Python 3.9+
 
 ### Performance
 - CPU usage: ~1-3% (mostly from terminal rendering)


### PR DESCRIPTION
The codebase already uses zoneinfo (Python 3.9+ stdlib) for timezone handling. This removes the now-unnecessary pytz from Rose.bat and documentation, eliminating the pkg_resources deprecation warning.