### PR TITLE
Fix critical bugs: IntradayDip crash, hardcoded size, and circuit bre…

### DIFF
--- a/intraday_dip_strategy.py
+++ b/intraday_dip_strategy.py
@@ -54,20 +54,21 @@ class IntradayDipStrategy(Strategy):
         curr_range = curr['high'] - curr['low']
         is_vol_spike = curr_range > range_sma
 
-        # Get dynamic SL/TP
-        sltp = dynamic_sltp_engine.calculate_dynamic_sltp(df)
-
         # LONG: Down 1%+, oversold (z < -0.5), volatility spike
         if (pct_change <= -1.0) and (z_score < -0.5) and is_vol_spike:
+            # Get dynamic SL/TP with strategy name for proper lookup
+            sltp = dynamic_sltp_engine.calculate_sltp("IntradayDip_LONG", df)
             logging.info(f"IntradayDip: LONG signal - Down {pct_change:.2f}%, Z={z_score:.2f}")
-            dynamic_sltp_engine.log_params(sltp)
+            dynamic_sltp_engine.log_params(sltp, "IntradayDip_LONG")
             return {"strategy": "IntradayDip", "side": "LONG",
                     "tp_dist": sltp['tp_dist'], "sl_dist": sltp['sl_dist']}
 
         # SHORT: Up 1.25%+, overbought (z > 1.0), volatility spike
         if (pct_change >= 1.25) and (z_score > 1.0) and is_vol_spike:
+            # Get dynamic SL/TP with strategy name for proper lookup
+            sltp = dynamic_sltp_engine.calculate_sltp("IntradayDip_SHORT", df)
             logging.info(f"IntradayDip: SHORT signal - Up {pct_change:.2f}%, Z={z_score:.2f}")
-            dynamic_sltp_engine.log_params(sltp)
+            dynamic_sltp_engine.log_params(sltp, "IntradayDip_SHORT")
             return {"strategy": "IntradayDip", "side": "SHORT",
                     "tp_dist": sltp['tp_dist'], "sl_dist": sltp['sl_dist']}
 


### PR DESCRIPTION
…aker units

1. IntradayDipStrategy crash fix:
   - Changed calculate_dynamic_sltp(df) to calculate_sltp("IntradayDip_LONG/SHORT", df)
   - Now passes strategy name so engine can lookup correct parameters
   - Updated log_params to include strategy name

2. Hardcoded size override fix:
   - place_order now uses signal.get('size', 5) instead of hardcoded 5
   - All 4 check_volatility calls now pass base_size=5 parameter
   - Volatility-adjusted size is now applied to signal['size']
   - All 3 active_trade assignments now use signal.get('size', 5)

3. Circuit breaker points vs dollars fix:
   - All 5 circuit_breaker.update_trade_result calls now convert points to dollars
   - Formula: pnl_dollars = pnl_points * 5.0 * contract_size (MES = $5/point)
   - Logging now shows both points and dollar amounts for clarity