### PR TITLE
Fix filter stacking order: move feasibility check to Layer 1

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -809,6 +809,27 @@ def run_bot():
                                 additional_info={"execution_type": "FAST"}
                             )
 
+                            # ==========================================
+                            # LAYER 1: TARGET FEASIBILITY CHECK (Master Gate)
+                            # ==========================================
+                            # The market condition check (chop) already happened globally.
+                            # Now check if the TARGET is realistic before wasting filter cycles.
+                            is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
+                                entry_price=current_price,
+                                side=signal['side'],
+                                tp_distance=signal.get('tp_dist', 6.0),
+                                df_1m=new_df
+                            )
+                            if not is_feasible:
+                                logging.info(f"⛔ Signal ignored (FAST): {feasibility_reason}")
+                                event_logger.log_filter_check("ChopFeasibility", signal['side'], False, feasibility_reason)
+                                continue
+                            else:
+                                event_logger.log_filter_check("ChopFeasibility", signal['side'], True)
+
+                            # ==========================================
+                            # LAYER 2: SIGNAL QUALITY FILTERS
+                            # ==========================================
                             # Filters - Rejection Filter
                             rej_blocked, rej_reason = rejection_filter.should_block_trade(signal['side'])
                             if rej_blocked:
@@ -937,21 +958,6 @@ def run_bot():
                                     f"Volatility regime adjustment (size={vol_adj['size']})"
                                 )
 
-                            # --- NEW: CHOP FEASIBILITY CHECK ---
-                            # Prevents taking trades in chop where the TP is outside the visible range.
-                            is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
-                                entry_price=current_price,
-                                side=signal['side'],
-                                tp_distance=signal.get('tp_dist', 6.0),
-                                df_1m=new_df
-                            )
-                            if not is_feasible:
-                                logging.info(f"🚫 Trade Skipped (FAST): {feasibility_reason}")
-                                event_logger.log_filter_check("ChopFeasibility", signal['side'], False, feasibility_reason)
-                                continue
-                            else:
-                                event_logger.log_filter_check("ChopFeasibility", signal['side'], True)
-
                             # Bank Filter (RegimeAdaptive Only)
                             bank_blocked, bank_reason = bank_filter.should_block_trade(signal['side'])
                             if bank_blocked:
@@ -1055,6 +1061,27 @@ def run_bot():
                                 additional_info={"execution_type": "STANDARD"}
                             )
 
+                            # ==========================================
+                            # LAYER 1: TARGET FEASIBILITY CHECK (Master Gate)
+                            # ==========================================
+                            # The market condition check (chop) already happened globally.
+                            # Now check if the TARGET is realistic before wasting filter cycles.
+                            is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
+                                entry_price=current_price,
+                                side=signal['side'],
+                                tp_distance=signal.get('tp_dist', 6.0),
+                                df_1m=new_df
+                            )
+                            if not is_feasible:
+                                logging.info(f"⛔ Signal ignored (STANDARD): {feasibility_reason}")
+                                event_logger.log_filter_check("ChopFeasibility", signal['side'], False, feasibility_reason)
+                                continue
+                            else:
+                                event_logger.log_filter_check("ChopFeasibility", signal['side'], True)
+
+                            # ==========================================
+                            # LAYER 2: SIGNAL QUALITY FILTERS
+                            # ==========================================
                             # Rejection Filter
                             rej_blocked, rej_reason = rejection_filter.should_block_trade(signal['side'])
                             if rej_blocked:
@@ -1175,21 +1202,6 @@ def run_bot():
                                     f"Volatility regime adjustment (size={vol_adj['size']})"
                                 )
 
-                            # --- NEW: CHOP FEASIBILITY CHECK ---
-                            # Prevents taking trades in chop where the TP is outside the visible range.
-                            is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
-                                entry_price=current_price,
-                                side=signal['side'],
-                                tp_distance=signal.get('tp_dist', 6.0),
-                                df_1m=new_df
-                            )
-                            if not is_feasible:
-                                logging.info(f"🚫 Trade Skipped (STANDARD): {feasibility_reason}")
-                                event_logger.log_filter_check("ChopFeasibility", signal['side'], False, feasibility_reason)
-                                continue
-                            else:
-                                event_logger.log_filter_check("ChopFeasibility", signal['side'], True)
-
                             # Bank Filter (ML Only)
                             if strat_name == "MLPhysicsStrategy":
                                 bank_blocked, bank_reason = bank_filter.should_block_trade(signal['side'])
@@ -1271,6 +1283,28 @@ def run_bot():
                                     logging.info(f"⛔ BLOCKED by HTF Range Rule: Signal {sig['side']} vs Allowed {allowed_chop_side}")
                                     del pending_loose_signals[s_name]
                                     continue
+
+                                # ==========================================
+                                # LAYER 1: TARGET FEASIBILITY CHECK (Master Gate)
+                                # ==========================================
+                                # The market condition check (chop) already happened globally.
+                                # Now check if the TARGET is realistic before wasting filter cycles.
+                                is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
+                                    entry_price=current_price,
+                                    side=sig['side'],
+                                    tp_distance=sig.get('tp_dist', 6.0),
+                                    df_1m=new_df
+                                )
+                                if not is_feasible:
+                                    logging.info(f"⛔ Signal ignored (LOOSE): {feasibility_reason}")
+                                    event_logger.log_filter_check("ChopFeasibility", sig['side'], False, feasibility_reason)
+                                    del pending_loose_signals[s_name]; continue
+                                else:
+                                    event_logger.log_filter_check("ChopFeasibility", sig['side'], True)
+
+                                # ==========================================
+                                # LAYER 2: SIGNAL QUALITY FILTERS
+                                # ==========================================
                                 # Re-check filters
                                 rej_blocked, rej_reason = rejection_filter.should_block_trade(sig['side'])
                                 if rej_blocked:
@@ -1394,21 +1428,6 @@ def run_bot():
                                         vol_adj['tp_dist'],
                                         f"Volatility regime adjustment (size={vol_adj['size']})"
                                     )
-
-                                # --- NEW: CHOP FEASIBILITY CHECK ---
-                                # Prevents taking trades in chop where the TP is outside the visible range.
-                                is_feasible, feasibility_reason = chop_analyzer.check_target_feasibility(
-                                    entry_price=current_price,
-                                    side=sig['side'],
-                                    tp_distance=sig.get('tp_dist', 6.0),
-                                    df_1m=new_df
-                                )
-                                if not is_feasible:
-                                    logging.info(f"🚫 Trade Skipped (LOOSE): {feasibility_reason}")
-                                    event_logger.log_filter_check("ChopFeasibility", sig['side'], False, feasibility_reason)
-                                    del pending_loose_signals[s_name]; continue
-                                else:
-                                    event_logger.log_filter_check("ChopFeasibility", sig['side'], True)
 
                                 logging.info(f"✅ LOOSE EXEC: {s_name}")
                                 event_logger.log_strategy_execution(s_name, "LOOSE")


### PR DESCRIPTION
Move ChopFeasibility check from position 13 (after volatility filter) to position 1 (immediately after signal generation) for all strategy types.

The correct filter stacking order is:
1. Global chop check (market condition - already at top)
2. TARGET FEASIBILITY CHECK (is TP realistic?) ← moved here
3. Signal quality filters (rejection, impulse, FVG, etc.)

This ensures we don't waste filter cycles on signals where the target is unrealistic before checking other conditions.