### PR TITLE
Revert rolling windows to LOOKBACK (20 bars) for high thresholds

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -155,20 +155,9 @@ def run_bot():
 
     # Initialize all strategies
 
-    # --- NEW: DETERMINE INITIAL SESSION FOR CALIBRATION ---
-    current_time_et = datetime.datetime.now(NY_TZ)
-    hour = current_time_et.hour
-    if 18 <= hour or hour < 3: initial_session = "ASIA"
-    elif 3 <= hour < 8: initial_session = "LONDON"
-    elif 8 <= hour < 12: initial_session = "NY_AM"
-    elif 12 <= hour < 17: initial_session = "NY_PM"
-    else: initial_session = "POST_MARKET"
-    # ------------------------------------------------------
-
     # Dynamic chop analyzer (tiered thresholds with LTF breakout override)
     chop_analyzer = DynamicChopAnalyzer(client)
-    # Pass the initial session so it uses the correct window (1 vs 2)
-    chop_analyzer.calibrate(session_name=initial_session)
+    chop_analyzer.calibrate()  # Removed session_name argument
     last_chop_calibration = time.time()
     
     # HIGH PRIORITY - Execute immediately on signal
@@ -292,8 +281,7 @@ def run_bot():
 
             # Periodic chop threshold recalibration (default every 4 hours)
             if chop_analyzer.should_recalibrate(last_chop_calibration):
-                # Pass the current session name to ensure we use the right logic
-                chop_analyzer.calibrate(session_name=current_session_name if 'current_session_name' in locals() else "NY_AM")
+                chop_analyzer.calibrate() # Removed session_name argument
                 last_chop_calibration = time.time()
 
             # === GLOBAL RISK & NEWS FILTERS ===


### PR DESCRIPTION
- Reverted 60M calibration from rolling(1) to rolling(self.LOOKBACK)
- Reverted 15M calibration from session-based rolling(1-2) to rolling(self.LOOKBACK)
- Removed session_name parameter from calibrate() method
- Removed session detection logic used only for calibration
- This restores high thresholds (e.g., 68.0, 21.5) for chop detection