### PR TITLE
Add Reversal strategy bypass and minimum range threshold for HTF Rang…

### DIFF
--- a/dynamic_chop.py
+++ b/dynamic_chop.py
@@ -129,7 +129,12 @@ class DynamicChopAnalyzer:
                 )
 
             current_price = df_1m_current["close"].iloc[-1]
-            if current_60m_vol > 0:
+
+            # [FIX] Only enforce Range Rule if the box is large enough (e.g., > 12 points)
+            # This prevents blocking trades inside tight micro-consolidations
+            MIN_RANGE_FOR_FADE = 12.0
+
+            if current_60m_vol > MIN_RANGE_FOR_FADE:
                 position_in_range = (current_price - current_60m_low) / current_60m_vol
 
                 if position_in_range <= 0.15:

--- a/julie001.py
+++ b/julie001.py
@@ -804,10 +804,15 @@ def run_bot():
                                 logging.info(f"🧠 GEMINI OPTIMIZED: {strat_name} | SL: {old_sl:.2f}->{signal['sl_dist']:.2f} (x{sl_mult}) | TP: {old_tp:.2f}->{signal['tp_dist']:.2f} (x{tp_mult})")
                             # ==========================================
 
-                            # Enforce HTF range fade directional restriction
-                            if allowed_chop_side is not None and signal['side'] != allowed_chop_side:
+                            # [FIX] Enforce HTF range fade directional restriction
+                            # EXCEPTION: Allow "Rev" (Reversal) strategies to bypass this rule
+                            is_reversal = "Rev" in signal.get('strategy', '') or "Rev" in signal.get('id', '')
+
+                            if not is_reversal and allowed_chop_side is not None and signal['side'] != allowed_chop_side:
                                 logging.info(f"⛔ BLOCKED by HTF Range Rule: Signal {signal['side']} vs Allowed {allowed_chop_side}")
                                 continue
+                            elif is_reversal and allowed_chop_side is not None and signal['side'] != allowed_chop_side:
+                                logging.info(f"⚡ HTF RULE BYPASS: {signal['strategy']} allowed to fight Range Bias ({allowed_chop_side})")
 
                             # Enhanced event logging: Strategy signal generated
                             event_logger.log_strategy_signal(
@@ -1075,10 +1080,15 @@ def run_bot():
                                 logging.info(f"🧠 GEMINI OPTIMIZED: {strat_name} | SL: {old_sl:.2f}->{signal['sl_dist']:.2f} (x{sl_mult}) | TP: {old_tp:.2f}->{signal['tp_dist']:.2f} (x{tp_mult})")
                             # ==========================================
 
-                            # Enforce HTF range fade directional restriction
-                            if allowed_chop_side is not None and signal['side'] != allowed_chop_side:
+                            # [FIX] Enforce HTF range fade directional restriction
+                            # EXCEPTION: Allow "Rev" (Reversal) strategies to bypass this rule
+                            is_reversal = "Rev" in signal.get('strategy', '') or "Rev" in signal.get('id', '')
+
+                            if not is_reversal and allowed_chop_side is not None and signal['side'] != allowed_chop_side:
                                 logging.info(f"⛔ BLOCKED by HTF Range Rule: Signal {signal['side']} vs Allowed {allowed_chop_side}")
                                 continue
+                            elif is_reversal and allowed_chop_side is not None and signal['side'] != allowed_chop_side:
+                                logging.info(f"⚡ HTF RULE BYPASS: {signal['strategy']} allowed to fight Range Bias ({allowed_chop_side})")
 
                             # Enhanced event logging: Strategy signal generated
                             event_logger.log_strategy_signal(


### PR DESCRIPTION
…e Rule

Fix 1: Allow "Rev" (Reversal) strategies to bypass the HTF Range Rule since reversals explicitly expect to break the range. Applied to both Fast Strategies and Standard execution paths in julie001.py.

Fix 2: Only enforce the Range Rule if the 60m box is larger than 12 points. This prevents blocking trades inside tight micro-consolidations where position in range is less meaningful.