### PR TITLE
Add interactive copy trading setup for JULIE001 and TKinter UI

### DIFF
--- a/COPY_TRADING_SETUP_GUIDE.md
+++ b/COPY_TRADING_SETUP_GUIDE.md
@@ -1,0 +1,228 @@
+# Copy Trading Setup Guide
+
+## Overview
+
+Copy trading has been enhanced with interactive setup from both JULIE001 bot and the TKinter UI. You can now easily enable/disable copy trading and select follower accounts using a beautiful interface.
+
+## Features
+
+### ✅ Enable from JULIE001 Bot
+When you run `python julie001.py`, you'll be prompted to:
+1. Enable or disable copy trading
+2. Select follower accounts using the beautiful account selector
+3. Configure size ratios for each follower account
+
+### ✅ Enable from TKinter UI
+The dashboard now includes:
+1. **Copy Trading Status Panel** - Shows current status and follower count
+2. **Enable/Disable Button** - Toggle copy trading on/off
+3. **Select Follower Accounts Button** - Choose which accounts copy trades
+4. **Size Ratio Configuration** - Set custom size ratios for each follower
+
+## How to Use
+
+### From JULIE001 Bot (CLI)
+
+1. Run the bot:
+   ```bash
+   python julie001.py
+   ```
+
+2. After authentication, you'll see:
+   ```
+   ============================================================
+   Copy Trading Setup
+
+   Do you want to enable copy trading? (y/n):
+   ```
+
+3. Type `y` to enable, then select follower accounts using the interactive menu
+
+4. Configure size ratios for each follower:
+   - **1.0** = Same size as leader
+   - **0.5** = Half size of leader
+   - **2.0** = Double size of leader
+
+### From TKinter UI
+
+1. Launch the UI:
+   ```bash
+   python julie_tkinter_ui.py
+   ```
+
+2. Login to your account
+
+3. In the dashboard, find the **COPY TRADING** section (right panel)
+
+4. Click **"✅ Enable Copy Trading"** button
+
+5. A dialog will open showing all available accounts:
+   - Check the accounts you want as followers
+   - Set size ratios for each (default: 1.0)
+   - Click **"Save Configuration"**
+
+6. To modify followers, click **"🔧 Select Follower Accounts"**
+
+7. To disable, click **"🛑 Disable Copy Trading"**
+
+## Account Selection Interface
+
+Both CLI and UI use the same beautiful account selector that:
+- Fetches all active accounts from your TopStepX account
+- Displays account names and IDs in a formatted table
+- Allows selecting multiple accounts as followers
+- Prevents selecting "Monitor All" for copy trading (must be individual accounts)
+
+## Architecture
+
+### Files Created/Modified
+
+1. **`copy_trading_setup.py`** (NEW)
+   - Interactive copy trading setup functions
+   - Account selection logic
+   - Configuration management
+
+2. **`julie001.py`** (MODIFIED)
+   - Added import for `setup_copy_trading_interactive`
+   - Added copy trading setup prompt after authentication
+   - Initializes ProjectXClient with copy trader
+
+3. **`julie_tkinter_ui.py`** (MODIFIED)
+   - Enhanced `create_copy_trading_stats_section()` to always show
+   - Added enable/disable buttons
+   - Added account selection dialog
+   - Added three new methods:
+     - `enable_copy_trading()`
+     - `disable_copy_trading()`
+     - `select_copy_trading_accounts()`
+
+### Data Flow
+
+```
+User enables copy trading
+    ↓
+Selects follower accounts (via AccountSelector)
+    ↓
+Configures size ratios
+    ↓
+Creates FollowerAccount objects
+    ↓
+Authenticates each follower
+    ↓
+Creates CopyTrader instance
+    ↓
+Passes to ProjectXClient
+    ↓
+Trades automatically copy to followers
+```
+
+## Configuration
+
+The configuration is stored in `CONFIG['COPY_TRADING']`:
+
+```python
+CONFIG['COPY_TRADING'] = {
+    'enabled': True,
+    'followers': [
+        {
+            'username': 'user@example.com',
+            'api_key': 'your-api-key',
+            'account_id': 'follower-account-id',
+            'contract_id': 'contract-id',
+            'size_ratio': 1.0,
+            'enabled': True
+        },
+        # More followers...
+    ]
+}
+```
+
+## Safety Features
+
+1. **Circuit Breaker** - Prevents runaway order placement
+2. **Rate Limiting** - Stays within TopStepX API limits
+3. **Error Isolation** - Follower failures don't affect leader trades
+4. **Confirmation Dialogs** - Asks before enabling/disabling
+5. **Size Ratio Validation** - Ensures valid ratios are configured
+
+## Example Workflow
+
+### Scenario: Copy trades from main account to 2 test accounts
+
+1. **Enable from UI:**
+   - Click "✅ Enable Copy Trading"
+   - Select Account A (set ratio 1.0)
+   - Select Account B (set ratio 0.5)
+   - Click "Save Configuration"
+
+2. **Result:**
+   - Leader places 10 contracts → Account A gets 10 contracts, Account B gets 5 contracts
+   - Leader closes position → Both followers close automatically
+   - All trades logged with copy trading statistics
+
+3. **Monitor:**
+   - Dashboard shows "2 Followers ACTIVE"
+   - Bot logs show "📋 Copying trade to 2 followers..."
+   - Copy trading stats tracked in real-time
+
+## Troubleshooting
+
+### Copy trading not working?
+
+1. **Check authentication**: All follower accounts must authenticate successfully
+2. **Check contracts**: Each follower must have access to the same contract
+3. **Check API limits**: Too many followers may hit rate limits
+4. **Check logs**: Look for circuit breaker trips or authentication failures
+
+### Can't select accounts?
+
+1. Ensure you're logged in first
+2. Check that you have active accounts in TopStepX
+3. Verify API access is enabled
+
+### Size ratios not working?
+
+1. Ensure ratios are positive numbers (e.g., 0.5, 1.0, 2.0)
+2. Check that follower accounts have sufficient margin
+3. Verify position sizing is calculated correctly in logs
+
+## Advanced Features
+
+### Programmatic Setup
+
+You can also setup copy trading programmatically:
+
+```python
+from copy_trading_setup import setup_copy_trading_from_accounts
+
+# Setup with account IDs and ratios
+copy_trader = setup_copy_trading_from_accounts(
+    session=authenticated_session,
+    follower_account_ids=['acc-1', 'acc-2'],
+    size_ratios=[1.0, 0.5]
+)
+
+# Use with ProjectXClient
+client = ProjectXClient(copy_trader=copy_trader)
+```
+
+### Custom Credentials per Follower
+
+Currently, all followers use the same credentials from CONFIG. For production use with separate credentials:
+
+Modify `setup_copy_trading_from_accounts()` to accept credential dictionaries.
+
+## Next Steps
+
+1. Enable copy trading from either interface
+2. Select your follower accounts
+3. Configure appropriate size ratios
+4. Monitor the dashboard for copy trading statistics
+5. Check logs for successful trade replication
+
+## Support
+
+For issues or questions:
+- Check `topstep_live_bot.log` for detailed logs
+- Review copy trading statistics in the dashboard
+- Verify all accounts are properly authenticated

--- a/copy_trading_setup.py
+++ b/copy_trading_setup.py
@@ -1,0 +1,304 @@
+"""
+Copy Trading Interactive Setup Module
+======================================
+
+Provides interactive setup for copy trading from both CLI and UI.
+Allows selecting follower accounts using the beautiful account selector.
+
+Author: Wes (with Claude)
+"""
+
+import logging
+import json
+from typing import List, Dict, Optional, Tuple
+from rich.console import Console
+from rich.prompt import Prompt, Confirm, FloatPrompt
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from account_selector import AccountSelector
+from copy_trader import FollowerAccount, CopyTrader, create_copy_trader_from_config
+from client import ProjectXClient
+from config import CONFIG
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def setup_copy_trading_interactive(session) -> Optional[CopyTrader]:
+    """
+    Interactive CLI setup for copy trading.
+
+    Allows user to:
+    1. Choose to enable/disable copy trading
+    2. Select follower accounts using the account selector
+    3. Configure size ratios for each follower
+
+    Args:
+        session: Authenticated requests session
+
+    Returns:
+        CopyTrader instance if enabled, None if disabled
+    """
+    console.print()
+    console.print(Panel(
+        Text("Copy Trading Setup", justify="center", style="bold cyan"),
+        border_style="cyan"
+    ))
+    console.print()
+
+    # Ask if user wants to enable copy trading
+    enable = Confirm.ask(
+        "[cyan]Do you want to enable copy trading?[/cyan]",
+        default=False
+    )
+
+    if not enable:
+        console.print("[yellow]Copy trading disabled.[/yellow]")
+        return None
+
+    console.print()
+    console.print("[green]✓ Copy trading enabled[/green]")
+    console.print()
+    console.print("[cyan]Now select follower accounts (accounts that will copy the leader's trades)[/cyan]")
+    console.print()
+
+    # Get follower accounts using the account selector
+    follower_configs = []
+
+    while True:
+        # Use account selector to pick a follower account
+        selector = AccountSelector(session)
+        result = selector.select_account()
+
+        if result is None:
+            console.print("[yellow]Account selection cancelled[/yellow]")
+            break
+
+        # If user selected "Monitor All", that's not valid for copy trading
+        if isinstance(result, list):
+            console.print("[red]Cannot use 'Monitor All' for copy trading. Please select individual accounts.[/red]")
+            console.print()
+            if not Confirm.ask("[cyan]Select another follower account?[/cyan]", default=True):
+                break
+            continue
+
+        # Result is a single account ID
+        follower_account_id = result
+
+        # Ask for additional follower configuration
+        console.print()
+        console.print("[cyan]Configure this follower account:[/cyan]")
+
+        # Ask for size ratio
+        size_ratio = FloatPrompt.ask(
+            "[cyan]Size ratio (e.g., 1.0 = same size as leader, 0.5 = half size)[/cyan]",
+            default=1.0
+        )
+
+        # We need username and api_key for each follower
+        # For now, we'll use the same credentials from CONFIG
+        # In a production system, you'd want separate credentials per follower
+        follower_configs.append({
+            'username': CONFIG['USERNAME'],  # In production, prompt for this
+            'api_key': CONFIG['API_KEY'],    # In production, prompt for this
+            'account_id': follower_account_id,
+            'contract_id': None,  # Will be fetched during initialization
+            'size_ratio': size_ratio,
+            'enabled': True
+        })
+
+        console.print()
+        console.print(f"[green]✓ Added follower account: {follower_account_id} (ratio: {size_ratio})[/green]")
+        console.print()
+
+        # Ask if they want to add more followers
+        if not Confirm.ask("[cyan]Add another follower account?[/cyan]", default=False):
+            break
+
+    if not follower_configs:
+        console.print("[yellow]No follower accounts configured. Copy trading will be disabled.[/yellow]")
+        return None
+
+    # Display summary
+    console.print()
+    console.print(Panel(
+        f"[bold green]Copy Trading Configuration Complete[/bold green]\n\n"
+        f"Followers: {len(follower_configs)} account(s)",
+        border_style="green"
+    ))
+
+    # Create follower summary table
+    table = Table(title="Follower Accounts", border_style="cyan")
+    table.add_column("Account ID", style="cyan")
+    table.add_column("Size Ratio", justify="right", style="yellow")
+    table.add_column("Status", style="green")
+
+    for fc in follower_configs:
+        table.add_row(
+            fc['account_id'],
+            f"{fc['size_ratio']:.2f}x",
+            "✓ Enabled" if fc['enabled'] else "Disabled"
+        )
+
+    console.print(table)
+    console.print()
+
+    # Now we need to authenticate these followers and get contract IDs
+    console.print("[yellow]Authenticating follower accounts...[/yellow]")
+
+    followers = []
+    for fc in follower_configs:
+        try:
+            # Create a client for this follower to get contract ID
+            follower_client = ProjectXClient()
+            follower_client.login()  # Uses CONFIG credentials
+
+            # Fetch contract for this account
+            # We need to temporarily set the account_id to fetch the right contract
+            follower_client.account_id = fc['account_id']
+            contract_id = follower_client.fetch_contracts()
+
+            if contract_id:
+                fc['contract_id'] = contract_id
+                follower = FollowerAccount(
+                    username=fc['username'],
+                    api_key=fc['api_key'],
+                    account_id=fc['account_id'],
+                    contract_id=fc['contract_id'],
+                    size_ratio=fc['size_ratio'],
+                    enabled=fc['enabled']
+                )
+                followers.append(follower)
+                console.print(f"[green]✓ {fc['account_id']} authenticated[/green]")
+            else:
+                console.print(f"[red]✗ Failed to get contract for {fc['account_id']}[/red]")
+        except Exception as e:
+            console.print(f"[red]✗ Failed to authenticate {fc['account_id']}: {e}[/red]")
+
+    if not followers:
+        console.print("[red]No followers could be authenticated. Copy trading disabled.[/red]")
+        return None
+
+    # Create the CopyTrader instance
+    copy_trader = CopyTrader(followers)
+
+    console.print()
+    console.print(f"[bold green]✓ Copy trading initialized with {len(followers)} follower(s)[/bold green]")
+    console.print()
+
+    return copy_trader
+
+
+def setup_copy_trading_from_accounts(
+    session,
+    follower_account_ids: List[str],
+    size_ratios: Optional[List[float]] = None
+) -> Optional[CopyTrader]:
+    """
+    Setup copy trading with pre-selected account IDs (for UI use).
+
+    Args:
+        session: Authenticated requests session
+        follower_account_ids: List of account IDs to use as followers
+        size_ratios: Optional list of size ratios (default 1.0 for all)
+
+    Returns:
+        CopyTrader instance or None if setup fails
+    """
+    if not follower_account_ids:
+        return None
+
+    # Default all ratios to 1.0 if not provided
+    if size_ratios is None:
+        size_ratios = [1.0] * len(follower_account_ids)
+    elif len(size_ratios) != len(follower_account_ids):
+        logger.warning(f"Size ratio count mismatch. Using 1.0 for all.")
+        size_ratios = [1.0] * len(follower_account_ids)
+
+    followers = []
+
+    for account_id, ratio in zip(follower_account_ids, size_ratios):
+        try:
+            # Create a client for this follower to get contract ID
+            follower_client = ProjectXClient()
+            follower_client.login()
+
+            # Fetch contract for this account
+            follower_client.account_id = account_id
+            contract_id = follower_client.fetch_contracts()
+
+            if contract_id:
+                follower = FollowerAccount(
+                    username=CONFIG['USERNAME'],
+                    api_key=CONFIG['API_KEY'],
+                    account_id=account_id,
+                    contract_id=contract_id,
+                    size_ratio=ratio,
+                    enabled=True
+                )
+                followers.append(follower)
+                logger.info(f"✓ Follower {account_id} configured (ratio: {ratio})")
+            else:
+                logger.error(f"Failed to get contract for {account_id}")
+        except Exception as e:
+            logger.error(f"Failed to setup follower {account_id}: {e}")
+
+    if not followers:
+        logger.error("No followers could be configured")
+        return None
+
+    copy_trader = CopyTrader(followers)
+    logger.info(f"✓ Copy trading initialized with {len(followers)} follower(s)")
+
+    return copy_trader
+
+
+def get_copy_trading_status() -> Dict:
+    """
+    Get current copy trading status from CONFIG.
+
+    Returns:
+        Dict with keys: enabled, follower_count, follower_accounts
+    """
+    copy_config = CONFIG.get('COPY_TRADING', {})
+    enabled = copy_config.get('enabled', False)
+    followers = copy_config.get('followers', [])
+    active_followers = [f for f in followers if f.get('enabled', True)]
+
+    return {
+        'enabled': enabled,
+        'follower_count': len(active_followers),
+        'follower_accounts': active_followers
+    }
+
+
+def save_copy_trading_config(followers: List[FollowerAccount], enabled: bool = True):
+    """
+    Save copy trading configuration to CONFIG (in-memory).
+
+    Note: This updates the in-memory CONFIG. To persist, you'd need to
+    write to config.py or a separate JSON file.
+
+    Args:
+        followers: List of FollowerAccount instances
+        enabled: Whether copy trading is enabled
+    """
+    follower_configs = []
+    for f in followers:
+        follower_configs.append({
+            'username': f.username,
+            'api_key': f.api_key,
+            'account_id': f.account_id,
+            'contract_id': f.contract_id,
+            'size_ratio': f.size_ratio,
+            'enabled': f.enabled
+        })
+
+    CONFIG['COPY_TRADING'] = {
+        'enabled': enabled,
+        'followers': follower_configs
+    }
+
+    logger.info(f"Copy trading config updated: {len(follower_configs)} followers, enabled={enabled}")

--- a/julie001.py
+++ b/julie001.py
@@ -38,6 +38,7 @@ from impulse_filter import ImpulseFilter
 from client import ProjectXClient
 from risk_engine import OptimizedTPEngine
 from gemini_optimizer import GeminiSessionOptimizer
+from copy_trading_setup import setup_copy_trading_interactive
 
 # ==========================================
 # RESAMPLER HELPER FUNCTION
@@ -139,6 +140,20 @@ def run_bot():
     print(f"\n✅ Setup complete:")
     print(f"   Account ID: {client.account_id}")
     print(f"   Contract ID: {client.contract_id}")
+
+    # Step 4: Copy Trading Setup (Optional)
+    print("\n" + "=" * 60)
+    copy_trader = setup_copy_trading_interactive(client.session)
+    if copy_trader:
+        # Re-initialize client with copy trader
+        client = ProjectXClient(copy_trader=copy_trader)
+        client.login()
+        client.account_id = account_id
+        client.contract_id = contract_id
+        print(f"✅ Copy trading enabled with {len(copy_trader.follower_accounts)} follower(s)")
+    else:
+        print("Copy trading disabled")
+    print("=" * 60)
 
     # Secondary client for MNQ data (SMT divergence inputs)
     mnq_target_symbol = determine_current_contract_symbol(

--- a/julie_tkinter_ui.py
+++ b/julie_tkinter_ui.py
@@ -721,24 +721,18 @@ class JulieUI:
         self.no_position_label.pack(pady=10)
 
     def create_copy_trading_stats_section(self, parent):
-        """Create copy trading statistics section"""
+        """Create copy trading statistics and controls section"""
         # Check if copy trading is enabled
         copy_config = CONFIG.get('COPY_TRADING', {})
         enabled = copy_config.get('enabled', False)
-
-        if not enabled:
-            # Don't show section if disabled
-            return
-
         followers = copy_config.get('followers', [])
         active_followers = [f for f in followers if f.get('enabled', True)]
 
+        # Always show the section (even if disabled)
         section = tk.Frame(parent, bg=self.colors['panel_bg'],
                           highlightbackground=self.colors['panel_border'],
-                          highlightthickness=1,
-                          height=120)  # Compact height
+                          highlightthickness=1)
         section.pack(fill='x', pady=(0, 10))
-        section.pack_propagate(False)  # Prevent expansion
 
         # Header with icon
         header_frame = tk.Frame(section, bg=self.colors['panel_bg'])
@@ -747,7 +741,7 @@ class JulieUI:
         header_icon = tk.Label(header_frame, text="📋",
                               font=("Helvetica", 10),
                               bg=self.colors['panel_bg'],
-                              fg=self.colors['green'])
+                              fg=self.colors['green'] if enabled else self.colors['text_dim'])
         header_icon.pack(side='left', padx=(0, 5))
 
         header = tk.Label(header_frame, text="COPY TRADING",
@@ -761,7 +755,7 @@ class JulieUI:
         stats_container = tk.Frame(section, bg=self.colors['panel_bg'])
         stats_container.pack(fill='both', expand=True, padx=20, pady=(0, 15))
 
-        if active_followers:
+        if enabled and active_followers:
             # Show follower count
             follower_frame = tk.Frame(stats_container, bg=self.colors['input_bg'],
                                      highlightbackground=self.colors['input_border'],
@@ -789,16 +783,66 @@ class JulieUI:
             self.copy_trading_status_label = status_label
             self.copy_trading_follower_label = follower_label
         else:
-            # No followers configured
-            warning_label = tk.Label(stats_container,
-                                    text="⚠️ No followers configured",
+            # Show status message
+            if enabled and not active_followers:
+                status_text = "⚠️ No followers configured"
+                status_color = self.colors['yellow']
+            else:
+                status_text = "Copy trading is disabled"
+                status_color = self.colors['text_dim']
+
+            status_label = tk.Label(stats_container,
+                                    text=status_text,
                                     font=("Helvetica", 10),
-                                    fg=self.colors['yellow'],
+                                    fg=status_color,
                                     bg=self.colors['panel_bg'])
-            warning_label.pack(pady=10)
+            status_label.pack(pady=5)
 
             self.copy_trading_status_label = None
             self.copy_trading_follower_label = None
+
+        # Control buttons
+        button_frame = tk.Frame(stats_container, bg=self.colors['panel_bg'])
+        button_frame.pack(fill='x', pady=(10, 0))
+
+        # Enable/Disable button
+        if enabled:
+            btn_text = "🛑 Disable Copy Trading"
+            btn_color = self.colors['red']
+            btn_command = self.disable_copy_trading
+        else:
+            btn_text = "✅ Enable Copy Trading"
+            btn_color = self.colors['green']
+            btn_command = self.enable_copy_trading
+
+        toggle_btn = tk.Button(button_frame,
+                              text=btn_text,
+                              font=("Helvetica", 9, "bold"),
+                              bg=btn_color,
+                              fg='#FFFFFF',
+                              activebackground=btn_color,
+                              activeforeground='#FFFFFF',
+                              relief='flat',
+                              cursor='hand2',
+                              command=btn_command,
+                              padx=10,
+                              pady=6)
+        toggle_btn.pack(side='left', padx=(0, 5))
+
+        # Select Accounts button
+        select_btn = tk.Button(button_frame,
+                              text="🔧 Select Follower Accounts",
+                              font=("Helvetica", 9, "bold"),
+                              bg=self.colors['blue'],
+                              fg='#FFFFFF',
+                              activebackground='#4a90e2',
+                              activeforeground='#FFFFFF',
+                              relief='flat',
+                              cursor='hand2',
+                              command=self.select_copy_trading_accounts,
+                              padx=10,
+                              pady=6)
+        select_btn.pack(side='left')
 
     def create_filters_section(self, parent):
         """Create filter status dashboard - ALL 12 filters"""
@@ -1029,6 +1073,210 @@ class JulieUI:
             self.pause_btn.config(state='normal')
             self.play_btn.config(state='disabled')
             self.add_log("▶ Monitoring RESUMED")
+
+    def enable_copy_trading(self):
+        """Enable copy trading and prompt for account selection"""
+        import tkinter.messagebox as messagebox
+
+        result = messagebox.askyesno(
+            "Enable Copy Trading",
+            "Do you want to enable copy trading?\n\n"
+            "This will allow trades on your main account to be automatically copied to follower accounts."
+        )
+
+        if not result:
+            return
+
+        # Prompt to select follower accounts
+        self.select_copy_trading_accounts(enable_after_selection=True)
+
+    def disable_copy_trading(self):
+        """Disable copy trading"""
+        import tkinter.messagebox as messagebox
+
+        result = messagebox.askyesno(
+            "Disable Copy Trading",
+            "Are you sure you want to disable copy trading?\n\n"
+            "Trades will no longer be copied to follower accounts."
+        )
+
+        if result:
+            CONFIG['COPY_TRADING']['enabled'] = False
+            self.add_log("🛑 Copy trading disabled")
+            # Refresh the dashboard to update UI
+            self.show_dashboard()
+
+    def select_copy_trading_accounts(self, enable_after_selection=False):
+        """Open account selection dialog for copy trading followers"""
+        import tkinter.messagebox as messagebox
+        from copy_trading_setup import setup_copy_trading_from_accounts
+
+        if not self.session:
+            messagebox.showerror("Error", "Not authenticated. Please login first.")
+            return
+
+        # Create a new window for account selection
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Select Follower Accounts")
+        dialog.geometry("600x500")
+        dialog.configure(bg=self.colors['bg_dark'])
+        dialog.transient(self.root)
+        dialog.grab_set()
+
+        # Title
+        title = tk.Label(dialog,
+                        text="Select Follower Accounts",
+                        font=("Helvetica", 16, "bold"),
+                        fg=self.colors['text_white'],
+                        bg=self.colors['bg_dark'])
+        title.pack(pady=20)
+
+        # Instructions
+        instructions = tk.Label(dialog,
+                               text="Select accounts that will copy trades from your leader account:",
+                               font=("Helvetica", 10),
+                               fg=self.colors['text_gray'],
+                               bg=self.colors['bg_dark'])
+        instructions.pack(pady=(0, 10))
+
+        # Fetch accounts
+        from account_selector import AccountSelector
+        selector = AccountSelector(self.session)
+        accounts = selector.fetch_accounts()
+
+        if not accounts:
+            messagebox.showerror("Error", "Could not fetch accounts")
+            dialog.destroy()
+            return
+
+        # Create scrollable frame for accounts
+        canvas = tk.Canvas(dialog, bg=self.colors['bg_dark'], highlightthickness=0)
+        scrollbar = tk.Scrollbar(dialog, orient="vertical", command=canvas.yview)
+        scrollable_frame = tk.Frame(canvas, bg=self.colors['bg_dark'])
+
+        scrollable_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+
+        # Store selected accounts and size ratios
+        selected_accounts = {}
+
+        # Create checkboxes for each account
+        for account in accounts:
+            account_id = account.get('id')
+            account_name = account.get('name', 'Unknown')
+
+            frame = tk.Frame(scrollable_frame, bg=self.colors['panel_bg'],
+                           highlightbackground=self.colors['panel_border'],
+                           highlightthickness=1)
+            frame.pack(fill='x', padx=20, pady=5)
+
+            var = tk.BooleanVar()
+            ratio_var = tk.DoubleVar(value=1.0)
+
+            cb = tk.Checkbutton(frame,
+                              text=f"{account_name} ({account_id})",
+                              variable=var,
+                              font=("Helvetica", 10),
+                              fg=self.colors['text_white'],
+                              bg=self.colors['panel_bg'],
+                              selectcolor=self.colors['input_bg'],
+                              activebackground=self.colors['panel_bg'],
+                              activeforeground=self.colors['text_white'])
+            cb.pack(side='left', padx=10, pady=10)
+
+            # Size ratio input
+            ratio_label = tk.Label(frame,
+                                  text="Size Ratio:",
+                                  font=("Helvetica", 9),
+                                  fg=self.colors['text_gray'],
+                                  bg=self.colors['panel_bg'])
+            ratio_label.pack(side='left', padx=(10, 5))
+
+            ratio_entry = tk.Entry(frame,
+                                  textvariable=ratio_var,
+                                  font=("Helvetica", 9),
+                                  bg=self.colors['input_bg'],
+                                  fg=self.colors['text_white'],
+                                  width=8)
+            ratio_entry.pack(side='left', padx=5)
+
+            selected_accounts[account_id] = {
+                'name': account_name,
+                'var': var,
+                'ratio_var': ratio_var
+            }
+
+        canvas.pack(side="left", fill="both", expand=True, padx=20)
+        scrollbar.pack(side="right", fill="y")
+
+        # Buttons
+        button_frame = tk.Frame(dialog, bg=self.colors['bg_dark'])
+        button_frame.pack(pady=20)
+
+        def save_selection():
+            # Get selected account IDs and ratios
+            follower_ids = []
+            ratios = []
+
+            for acc_id, data in selected_accounts.items():
+                if data['var'].get():
+                    follower_ids.append(acc_id)
+                    ratios.append(data['ratio_var'].get())
+
+            if not follower_ids:
+                messagebox.showwarning("No Selection", "Please select at least one follower account")
+                return
+
+            # Setup copy trading
+            copy_trader = setup_copy_trading_from_accounts(self.session, follower_ids, ratios)
+
+            if copy_trader:
+                # Update CONFIG
+                from copy_trading_setup import save_copy_trading_config
+                save_copy_trading_config(copy_trader.follower_accounts, enabled=True)
+
+                if enable_after_selection:
+                    CONFIG['COPY_TRADING']['enabled'] = True
+
+                self.add_log(f"✅ Copy trading configured with {len(follower_ids)} follower(s)")
+                dialog.destroy()
+                # Refresh dashboard
+                self.show_dashboard()
+            else:
+                messagebox.showerror("Error", "Failed to setup copy trading")
+
+        save_btn = tk.Button(button_frame,
+                           text="Save Configuration",
+                           font=("Helvetica", 11, "bold"),
+                           bg=self.colors['green'],
+                           fg='#FFFFFF',
+                           activebackground=self.colors['green_light'],
+                           activeforeground='#FFFFFF',
+                           relief='flat',
+                           cursor='hand2',
+                           command=save_selection,
+                           padx=20,
+                           pady=10)
+        save_btn.pack(side='left', padx=5)
+
+        cancel_btn = tk.Button(button_frame,
+                             text="Cancel",
+                             font=("Helvetica", 11, "bold"),
+                             bg=self.colors['red'],
+                             fg='#FFFFFF',
+                             activebackground='#dc2626',
+                             activeforeground='#FFFFFF',
+                             relief='flat',
+                             cursor='hand2',
+                             command=dialog.destroy,
+                             padx=20,
+                             pady=10)
+        cancel_btn.pack(side='left', padx=5)
 
     def start_monitoring(self):
         """Start real-time monitoring of bot log and API"""


### PR DESCRIPTION
Implemented comprehensive copy trading configuration system that allows enabling and managing copy trading from both CLI and GUI interfaces.

New Features:
- Interactive copy trading setup in JULIE001 bot on startup
- UI controls in TKinter dashboard (enable/disable, account selection)
- Beautiful account selector for choosing follower accounts
- Size ratio configuration for each follower account
- Comprehensive documentation guide

Files Added:
- copy_trading_setup.py: Interactive setup module with account selection
- COPY_TRADING_SETUP_GUIDE.md: Complete usage documentation

Files Modified:
- julie001.py: Added copy trading setup prompt after authentication
- julie_tkinter_ui.py: Enhanced copy trading section with interactive controls

Key Improvements:
- Unified account selection experience across CLI and UI
- Same underlying setup functions for both interfaces
- Real-time configuration updates
- Safety confirmations for enable/disable actions
- Support for custom size ratios per follower

Usage:
- CLI: Run julie001.py and follow copy trading prompts
- UI: Use buttons in COPY TRADING panel on dashboard