### PR TITLE
Add Loaded Spring logic to check_target_feasibility in dynamic_chop.py

### DIFF
--- a/dynamic_chop.py
+++ b/dynamic_chop.py
@@ -177,6 +177,16 @@ class DynamicChopAnalyzer:
         if df_1m.empty or len(df_1m) < self.LOOKBACK:
              return True, "Insufficient Data"
 
+        # --- NEW: LOADED SPRING (Time Decay Fader) ---
+        # Check volatility of the last 15 bars (approx 15 mins)
+        recent_15_high = df_1m["high"].iloc[-15:].max()
+        recent_15_low = df_1m["low"].iloc[-15:].min()
+        recent_15_vol = recent_15_high - recent_15_low
+
+        # Threshold: If 15-min range is < 7 points, it's a "Loaded Spring"
+        if recent_15_vol < 7.0:
+            return True, f"⚡ LOADED SPRING: 15m Range only {recent_15_vol:.2f}pts. Allowing Breakout Attempt."
+
         # =========================================================
         # 1. REGIME CHECK (The Safety Switch)
         # =========================================================


### PR DESCRIPTION
- Added time decay fader logic that checks last 15 bars volatility
- If 15-min range < 7 points, allows breakout attempt with LOADED SPRING message
- Placed before regime check to override restrictive conditions