### PR TITLE
Enforce 4.0 SL / 6.0 TP minimums in all SLTP sources

### DIFF
--- a/dynamic_sltp_params.py
+++ b/dynamic_sltp_params.py
@@ -3051,9 +3051,9 @@ class DynamicSLTPEngine:
         sl_dist = round(sl_dist * 4) / 4
         tp_dist = round(tp_dist * 4) / 4
 
-        # THEN enforce minimums AFTER snapping
-        sl_dist = max(sl_dist, 1.0)  # 4 ticks minimum
-        tp_dist = max(tp_dist, 1.5)  # 6 ticks minimum
+        # THEN enforce minimums AFTER snapping (4.0 SL, 6.0 TP for positive RR)
+        sl_dist = max(sl_dist, 4.0)  # 16 ticks minimum
+        tp_dist = max(tp_dist, 6.0)  # 24 ticks minimum (1.5:1 RR)
 
         return {
             'sl_dist': sl_dist,

--- a/regime_strategy.py
+++ b/regime_strategy.py
@@ -114,26 +114,32 @@ def should_revert_signal(ts) -> bool:
 def get_optimized_sltp(side: str, ts) -> Dict[str, float]:
     """
     Get optimized SL/TP for the given side and timestamp.
-    
+
     Returns dict with 'sl_dist' and 'tp_dist'
     """
+    # Minimum enforcement for positive RR
+    MIN_SL = 4.0  # 16 ticks minimum
+    MIN_TP = 6.0  # 24 ticks minimum (1.5:1 RR)
+
     ctx = get_time_context(ts)
-    
+
     if SLTP_PARAMS_AVAILABLE:
         params = get_regime_sltp(
-            side, 
-            ctx['yearly_q'], 
-            ctx['monthly_q'], 
-            ctx['day_of_week'], 
+            side,
+            ctx['yearly_q'],
+            ctx['monthly_q'],
+            ctx['day_of_week'],
             ctx['session']
         )
+        sl_dist = max(params['sl'], MIN_SL)
+        tp_dist = max(params['tp'], MIN_TP)
         return {
-            'sl_dist': params['sl'],
-            'tp_dist': params['tp']
+            'sl_dist': sl_dist,
+            'tp_dist': tp_dist
         }
-    
+
     # Defaults if no params available
-    return {'sl_dist': 4.0, 'tp_dist': 6.0}
+    return {'sl_dist': MIN_SL, 'tp_dist': MIN_TP}
 
 
 class RegimeAdaptiveStrategy:


### PR DESCRIPTION
- dynamic_sltp_params.py: Changed min from 1.0/1.5 to 4.0/6.0
- regime_strategy.py: Added MIN_SL/MIN_TP enforcement in get_optimized_sltp() (regime_sltp_params.py has hardcoded values as low as 0.8)

This ensures all strategies output SL >= 4.0 and TP >= 6.0 regardless of:
- Hardcoded params in regime_sltp_params.py
- Dynamic ATR calculations in dynamic_sltp_params.py
- Gemini multiplier reductions