### PR TITLE
Fix remaining SL/TP minimum enforcement gaps

### DIFF
--- a/dynamic_engine_strategy.py
+++ b/dynamic_engine_strategy.py
@@ -60,12 +60,19 @@ class DynamicEngineStrategy(Strategy):
 
             logging.info(f"🚀 DYNAMIC ENGINE TRIGGER: {signal_data['strategy_id']}")
 
+            # Enforce minimum SL/TP for positive RR
+            MIN_SL = 4.0  # 16 ticks minimum
+            MIN_TP = 6.0  # 24 ticks minimum (1.5:1 RR)
+
+            final_sl = max(signal_data['sl'], MIN_SL)
+            final_tp = max(signal_data['tp'], MIN_TP)
+
             return {
                 "strategy": "DynamicEngine",
                 "sub_strategy": signal_data['strategy_id'],
                 "side": signal_data['signal'],
-                "tp_dist": signal_data['tp'],
-                "sl_dist": signal_data['sl']
+                "tp_dist": final_tp,
+                "sl_dist": final_sl
             }
 
         return None

--- a/volatility_filter.py
+++ b/volatility_filter.py
@@ -553,9 +553,9 @@ class HierarchicalVolatilityFilter:
         adj_sl = round(adj_sl * 4) / 4
         adj_tp = round(adj_tp * 4) / 4
 
-        # Minimum constraints (MES minimums)
-        adj_sl = max(adj_sl, 1.0)  # Absolute minimum stop
-        adj_tp = max(adj_tp, 1.0)
+        # Minimum constraints (4.0 SL / 6.0 TP for positive RR)
+        adj_sl = max(adj_sl, 4.0)  # 16 ticks minimum
+        adj_tp = max(adj_tp, 6.0)  # 24 ticks minimum (1.5:1 RR)
 
         return {
             'sl_dist': adj_sl,


### PR DESCRIPTION
- volatility_filter.py: Changed minimums from 1.0/1.0 to 4.0/6.0
- dynamic_engine_strategy.py: Added MIN_SL=4.0, MIN_TP=6.0 enforcement (was passing engine values directly without validation)

All SLTP sources now enforce 4.0 SL / 6.0 TP minimums.