### PR TITLE
Remove Dynamic Engine 2 strategy from bot

### DIFF
--- a/config.py
+++ b/config.py
@@ -90,11 +90,6 @@ CONFIG = {
             "exit_if_not_green_by": 30,   # Give trade room to develop
             "max_profit_crosses": 4,      # Allow some chop
         },
-        "DynamicEngine2": {
-            "enabled": True,
-            "exit_if_not_green_by": 30,   # Give trade room to develop
-            "max_profit_crosses": 4,      # Allow some chop
-        },
         "ORB_Long": {"enabled": False},
     },
 

--- a/julie001.py
+++ b/julie001.py
@@ -30,7 +30,6 @@ from dynamic_chop import DynamicChopAnalyzer
 from ict_model_strategy import ICTModelStrategy
 from ml_physics_strategy import MLPhysicsStrategy
 from dynamic_engine_strategy import DynamicEngineStrategy
-from dynamic_engine2_strategy import DynamicEngine2Strategy
 from event_logger import event_logger
 from circuit_breaker import CircuitBreaker
 from news_filter import NewsFilter
@@ -271,13 +270,11 @@ def run_bot():
     # STANDARD PRIORITY - Normal execution
     ml_strategy = MLPhysicsStrategy()
     dynamic_engine_strat = DynamicEngineStrategy()
-    dynamic_engine2_strat = DynamicEngine2Strategy()
     smt_strategy = SMTStrategy()
 
     standard_strategies = [
         ConfluenceStrategy(),
         dynamic_engine_strat,
-        dynamic_engine2_strat,
         smt_strategy,
     ]
     
@@ -1422,8 +1419,8 @@ def run_bot():
                                                  else "NEUTRAL"))
                             vol_regime, _, _ = volatility_filter.get_regime(new_df)
 
-                            # Chop (Except DynamicEngine/DynamicEngine2)
-                            if signal['strategy'] not in ["DynamicEngine", "DynamicEngine2"]:
+                            # Chop (Except DynamicEngine)
+                            if signal['strategy'] not in ["DynamicEngine"]:
                                 chop_blocked, chop_reason = chop_filter.should_block_trade(
                                     signal['side'],
                                     rejection_filter.prev_day_pm_bias,
@@ -1437,8 +1434,8 @@ def run_bot():
                                 else:
                                     event_logger.log_filter_check("ChopFilter", signal['side'], True, strategy=signal.get('strategy', strat_name))
 
-                            # Extension (Except DynamicEngine/DynamicEngine2)
-                            if signal['strategy'] not in ["DynamicEngine", "DynamicEngine2"]:
+                            # Extension (Except DynamicEngine)
+                            if signal['strategy'] not in ["DynamicEngine"]:
                                 ext_blocked, ext_reason = extension_filter.should_block_trade(signal['side'])
                                 if ext_blocked:
                                     event_logger.log_filter_check("ExtensionFilter", signal['side'], False, ext_reason, strategy=signal.get('strategy', strat_name))

--- a/julie_tkinter_ui.py
+++ b/julie_tkinter_ui.py
@@ -538,7 +538,6 @@ class JulieUI:
             "ORB Strategy",
             "ML Physics",
             "Dynamic Engine 1",
-            "Dynamic Engine 2",
             "SMT Divergence"
         ]
 
@@ -1025,7 +1024,6 @@ class JulieUI:
                     "MLPhysicsStrategy": "ML Physics",
                     "MLPhysics": "ML Physics",
                     "DynamicEngine": "Dynamic Engine 1",
-                    "DynamicEngine2": "Dynamic Engine 2",
                     "SMTStrategy": "SMT Divergence"
                 }
 


### PR DESCRIPTION
- Remove DynamicEngine2Strategy import and instantiation from julie001.py
- Remove dynamic_engine2_strat from standard_strategies list
- Remove DynamicEngine2 from Chop and Extension filter bypass exceptions
- Remove DynamicEngine2 config from config.py early exit settings
- Remove Dynamic Engine 2 from UI strategy list and mapping

The strategy files (dynamic_engine2_strategy.py, dynamic_signal_engine2.py) are preserved but no longer active in the bot.