### PR TITLE
Increase Gemini API timeout from 45s to 300s for thinking mode

### DIFF
--- a/gemini_optimizer.py
+++ b/gemini_optimizer.py
@@ -373,7 +373,8 @@ class GeminiSessionOptimizer:
                 }
             }
         }
-        response = requests.post(self.url, headers=self.headers, json=payload, timeout=45)
+        # CHANGE: Increased timeout from 45 to 300 to accommodate "thinking" time
+        response = requests.post(self.url, headers=self.headers, json=payload, timeout=300)
         if response.status_code == 200:
             return response.json()['candidates'][0]['content']['parts'][0]['text']
         raise Exception(f"API Status {response.status_code}")


### PR DESCRIPTION
The thinkingConfig with "thinkingLevel": "high" requires more time for the model to process. Increased timeout to accommodate this.