### PR TITLE
🐛 Fix UnboundLocalError: Remove redundant 'import time' statements

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -960,7 +960,6 @@ async def run_bot():
                             logging.info(f"📊 CANDIDATE (FAST): {strat_name} {signal['side']} @ {current_price:.2f}")
 
                             # === START LATENCY TIMER FOR FILTER STACK ===
-                            import time
                             filter_start_time = time.time() * 1000  # Convert to ms
 
                             # ==========================================
@@ -1289,7 +1288,6 @@ async def run_bot():
                             logging.info(f"📊 CANDIDATE (STANDARD): {strat_name} {signal['side']} @ {current_price:.2f}")
 
                             # === START LATENCY TIMER FOR FILTER STACK ===
-                            import time
                             filter_start_time = time.time() * 1000  # Convert to ms
 
                             # ==========================================


### PR DESCRIPTION
- Removed duplicate 'import time' statements inside nested blocks (lines 963 & 1292)
- Time module is already imported at module level (line 6)
- Redundant local imports were causing UnboundLocalError in certain code paths