### PR TITLE
🔧 Fix Data Freshness Check Death Loop

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -340,9 +340,9 @@ async def run_bot():
 
                 if seconds_since_last_update > 60:
                     event_logger.log_error("DATA_STALE", f"🚨 DATA LAG: Last update was {seconds_since_last_update:.0f}s ago. Moving to DEFENSIVE mode.")
-                    logging.warning(f"🚨 DATA LAG: Last update was {seconds_since_last_update:.0f}s ago. Waiting for fresh data...")
+                    logging.warning(f"🚨 DATA LAG: Last update was {seconds_since_last_update:.0f}s ago. Attempting to fetch fresh data...")
                     await asyncio.sleep(5)
-                    continue
+                    # continue  # Removed: Allow bot to proceed to data fetch even when stale
 
             # Periodic chop threshold recalibration (default every 4 hours)
             if chop_analyzer.should_recalibrate(last_chop_calibration):


### PR DESCRIPTION
Remove `continue` statement from DATA FRESHNESS CHECK block to allow the bot to proceed to data fetching even when current data is stale.

Before: Bot would loop forever when data was older than 60 seconds, never attempting to fetch new data (e.g., after market holidays).

After: Bot logs the stale data warning but continues to the fetch step, allowing it to recover once the market reopens.