### PR TITLE
Update SHARED_MIN_FETCH_INTERVAL from 0.5 to 0.8 seconds

### DIFF
--- a/client.py
+++ b/client.py
@@ -38,7 +38,7 @@ class ProjectXClient:
     SHARED_BAR_RATE_WINDOW = 30
     SHARED_GENERAL_RATE_LIMIT = 200
     SHARED_GENERAL_RATE_WINDOW = 60
-    SHARED_MIN_FETCH_INTERVAL = 0.5  # Minimum 500ms between any bar fetches across all instances
+    SHARED_MIN_FETCH_INTERVAL = 0.8  # Minimum 800ms between any bar fetches across all instances
 
     @classmethod
     def _get_lock(cls):


### PR DESCRIPTION
0.8s * 37 requests = ~29.6 seconds, keeping safely under the 40-request limit for continuous fresh data.