### PR TITLE
Add comprehensive logging to dual filter system

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -1216,6 +1216,11 @@ async def run_bot():
                         # Both agree - use upgraded decision
                         trend_blocked = upgraded_trend_blocked
                         trend_reason = upgraded_trend_reason
+                        # Log when both agree (so we know dual-filter is running)
+                        if trend_blocked:
+                            logging.info(f"🛡️ DUAL-FILTER: Both BLOCK {signal['side']} | reason: {trend_reason}")
+                        else:
+                            logging.info(f"✅ DUAL-FILTER: Both ALLOW {signal['side']} trend check")
 
                     trend_state = ("Strong Bearish" if (trend_reason and "Bearish" in str(trend_reason))
                                    else ("Strong Bullish" if (trend_reason and "Bullish" in str(trend_reason))
@@ -1508,6 +1513,11 @@ async def run_bot():
                                 else:
                                     trend_blocked = upgraded_trend_blocked
                                     trend_reason = upgraded_trend_reason
+                                    # Log when both agree (so we know dual-filter is running)
+                                    if trend_blocked:
+                                        logging.info(f"🛡️ DUAL-FILTER: Both BLOCK {sig['side']} | reason: {trend_reason}")
+                                    else:
+                                        logging.info(f"✅ DUAL-FILTER: Both ALLOW {sig['side']} trend check")
 
                                 trend_state = ("Strong Bearish" if (trend_reason and "Bearish" in str(trend_reason))
                                                else ("Strong Bullish" if (trend_reason and "Bullish" in str(trend_reason))
@@ -1742,6 +1752,11 @@ async def run_bot():
                                         else:
                                             trend_blocked = upgraded_trend_blocked
                                             trend_reason = upgraded_trend_reason
+                                            # Log when both agree (so we know dual-filter is running)
+                                            if trend_blocked:
+                                                logging.info(f"🛡️ DUAL-FILTER: Both BLOCK {signal['side']} | reason: {trend_reason}")
+                                            else:
+                                                logging.info(f"✅ DUAL-FILTER: Both ALLOW {signal['side']} trend check")
 
                                         trend_state = ("Strong Bearish" if (trend_reason and "Bearish" in str(trend_reason))
                                                        else ("Strong Bullish" if (trend_reason and "Bullish" in str(trend_reason))


### PR DESCRIPTION
Previously the dual filter arbitrator only logged when a disagreement occurred AND required override analysis (Case 4). This left no visibility when:
- Both filters agreed to BLOCK (Case 1)
- Both filters agreed to ALLOW (Case 2)
- Legacy blocked but upgraded allowed (Case 3)

Added logging to all 4 decision cases with clear emoji indicators:
- 🛡️ Case 1: Both BLOCK
- ✅ Case 2: Both ALLOW
- 🔄 Case 3: Legacy BLOCK, Upgraded ALLOW
- ⚖️ Case 4: Legacy ALLOW, Upgraded BLOCK → Analysis

Also added logging in julie001.py for when both filters agree (no arbitration needed) so the user can see the dual filter system is actively running.