### PR TITLE
[codex] add public filterless zip 20260413

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+julie_filterless_public_*.zip filter=lfs diff=lfs merge=lfs -text

--- a/julie_filterless_public_20260413_public.zip
+++ b/julie_filterless_public_20260413_public.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d68451ebb3d6e88ba06a9b42f5b487d1e435a4750bad49217c02eb43ea943a3a
+size 338334168


### PR DESCRIPTION
## What changed
Adds the new public-safe filterless bot package zip for April 13, 2026.

## Why
This publishes the latest shareable build to GitHub without exposing local config secrets.

## Notes
The zip is stored through Git LFS.
The package was verified locally to replace `config_secrets.py` with environment-based placeholders and to avoid leaking the live username, API keys, Gemini key, or local workspace path.

## Validation
Built `julie_filterless_public_20260413_public.zip` locally.
Scanned the packaged artifact for the real secrets and local path with no matches.
Computed SHA-256: `D68451EBB3D6E88BA06A9B42F5B487D1E435A4750BAD49217C02EB43EA943A3A`.