### PR TITLE
Centralize Kalshi credentials and disable provider when secrets missing

### DIFF
--- a/config.py
+++ b/config.py
@@ -734,7 +734,7 @@ CONFIG = {
     },
     "KALSHI": {
         "key_id": str(SECRETS.get("KALSHI_KEY_ID", "") or ""),
-        "private_key_path": str(SECRETS.get("KALSHI_PRIVATE_KEY_PATH", "credentials/kalshi_key.pem") or "credentials/kalshi_key.pem"),
+        "private_key_path": str(SECRETS.get("KALSHI_PRIVATE_KEY_PATH", "") or ""),
         "base_url": "https://api.elections.kalshi.com/trade-api/v2",
         "series": "KXINXU",
         "polling_interval": 300,

--- a/config_secrets.example.py
+++ b/config_secrets.example.py
@@ -7,4 +7,6 @@ SECRETS = {
     "USERNAME": os.environ.get("TOPSTEPX_USERNAME", ""),
     "API_KEY": os.environ.get("TOPSTEPX_API_KEY", ""),
     "GEMINI_API_KEY": os.environ.get("GEMINI_API_KEY", ""),
+    "KALSHI_KEY_ID": os.environ.get("KALSHI_KEY_ID", "your-key-id-here"),
+    "KALSHI_PRIVATE_KEY_PATH": os.environ.get("KALSHI_PRIVATE_KEY_PATH", "path/to/your/kalshi_key.pem"),
 }

--- a/julie_ui.py
+++ b/julie_ui.py
@@ -15,6 +15,10 @@ from config import CONFIG
 from terminal_ui import get_ui
 from account_selector import select_account_interactive
 from aetherflow_features import generate_daily_miva
+try:
+    from config_secrets import SECRETS
+except Exception:
+    SECRETS = {}
 
 try:
     from services.kalshi_provider import KalshiProvider
@@ -392,6 +396,12 @@ def main():
     api_monitor = APIMonitor()
     kalshi = None
     kalshi_cfg = CONFIG.get("KALSHI", {}) if isinstance(CONFIG, dict) else {}
+    if isinstance(kalshi_cfg, dict):
+        kalshi_cfg = dict(kalshi_cfg)
+        kalshi_cfg["key_id"] = str(SECRETS.get("KALSHI_KEY_ID", kalshi_cfg.get("key_id", "")) or "")
+        kalshi_cfg["private_key_path"] = str(
+            SECRETS.get("KALSHI_PRIVATE_KEY_PATH", kalshi_cfg.get("private_key_path", "")) or ""
+        )
 
     if not api_monitor.login():
         ui.add_event("ERROR", "Failed to authenticate - check config.py credentials")

--- a/services/kalshi_provider.py
+++ b/services/kalshi_provider.py
@@ -20,6 +20,7 @@ class KalshiProvider:
     """
 
     def __init__(self, config: Dict):
+        config = config or {}
         self.key_id = str(config.get("key_id", "") or "")
         self.base_url = str(config.get("base_url", "") or "").rstrip("/")
         self.series = str(config.get("series", "KXINXU") or "KXINXU")
@@ -33,8 +34,16 @@ class KalshiProvider:
         self.private_key = None
         private_key_path = str(config.get("private_key_path", "") or "")
         if private_key_path:
-            with open(private_key_path, "rb") as key_file:
-                self.private_key = serialization.load_pem_private_key(key_file.read(), password=None)
+            try:
+                with open(private_key_path, "rb") as key_file:
+                    self.private_key = serialization.load_pem_private_key(key_file.read(), password=None)
+            except (FileNotFoundError, OSError, ValueError) as exc:
+                logger.warning("Unable to load Kalshi private key from %s: %s", private_key_path, exc)
+
+        if not self.key_id or self.private_key is None:
+            if self.enabled:
+                logger.warning("Kalshi credentials missing or invalid; provider disabled")
+            self.enabled = False
 
         self._cache: Dict[str, Dict] = {}
         self._cache_lock = threading.Lock()


### PR DESCRIPTION
### Motivation
- Centralize Kalshi API credentials into the project's secrets system so credentials can be supplied from `config_secrets.py`/environment rather than hardcoded paths.
- Prevent runtime crashes when Kalshi credentials or private key files are absent or invalid by ensuring the provider can be safely disabled.

### Description
- Added `KALSHI_KEY_ID` and `KALSHI_PRIVATE_KEY_PATH` placeholders to `config_secrets.example.py` so secrets can be provided via `SECRETS` or environment variables.
- Updated `CONFIG["KALSHI"]` in `config.py` to read `private_key_path` from `SECRETS` without a hardcoded fallback path so the runtime config reflects centrally managed secrets.
- Hardened `KalshiProvider.__init__` in `services/kalshi_provider.py` to normalize `config`, catch key-loading errors (`FileNotFoundError`, `OSError`, `ValueError`) without raising, and automatically set `self.enabled = False` when `key_id` or the private key is missing or invalid.
- Wired secrets into the client instantiation flow in `julie_ui.py` by importing `SECRETS` and injecting `key_id` and `private_key_path` into `kalshi_cfg` before creating `KalshiProvider` so the provider is constructed from the central secret store.

### Testing
- Ran `python -m compileall config_secrets.example.py services/kalshi_provider.py julie_ui.py config.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df53783ea0832a8e628780f1a0d02f)