### PR TITLE
Expose Kalshi strike probabilities and 60m sentiment in filterless live dashboard and UI

### DIFF
--- a/launch_filterless_live.py
+++ b/launch_filterless_live.py
@@ -1,9 +1,14 @@
 import asyncio
+import json
 import os
 import platform
 import socket
 import sys
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, Optional
+
+from zoneinfo import ZoneInfo
 
 
 def _force_utf8_stdio() -> None:
@@ -82,7 +87,13 @@ _stabilize_windows_platform_queries()
 os.environ.setdefault("JULIE_FILTERLESS_ONLY", "1")
 os.environ.setdefault("JULIE_DISABLE_STRATEGY_FILTERS", "1")
 
+from bot_state import load_bot_state
+from config import CONFIG
+from config_secrets import SECRETS
+from julie001 import run_bot
 from process_singleton import acquire_singleton_lock
+from services.kalshi_provider import KalshiProvider
+from tools.filterless_dashboard_bridge import DEFAULT_KALSHI_SNAPSHOT_PATH, write_json_atomic
 
 
 LIVE_LOCK_PATH = Path(__file__).resolve().parent / "logs" / "filterless_live.lock"
@@ -101,8 +112,113 @@ if LIVE_LOCK is None:
         print(existing)
     raise SystemExit(0)
 
-from julie001 import run_bot
+
+NY_TZ = ZoneInfo("America/New_York")
+ROOT = Path(__file__).resolve().parent
+BRIDGE_SCRIPT = ROOT / "tools" / "filterless_dashboard_bridge.py"
+
+
+def _coerce_price_from_state() -> Optional[float]:
+    state = load_bot_state(ROOT / "bot_state.json")
+    if not isinstance(state, dict):
+        return None
+    live_position = state.get("live_position")
+    if isinstance(live_position, dict):
+        for key in ("current_price", "avg_price", "entry_price"):
+            value = live_position.get(key)
+            if value is None:
+                continue
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _build_kalshi_provider() -> Optional[KalshiProvider]:
+    kalshi_cfg = CONFIG.get("KALSHI", {}) if isinstance(CONFIG, dict) else {}
+    if not isinstance(kalshi_cfg, dict):
+        return None
+    provider_cfg = dict(kalshi_cfg)
+    provider_cfg["key_id"] = str(SECRETS.get("KALSHI_KEY_ID", provider_cfg.get("key_id", "")) or "")
+    provider_cfg["private_key_path"] = str(
+        SECRETS.get("KALSHI_PRIVATE_KEY_PATH", provider_cfg.get("private_key_path", "")) or ""
+    )
+    provider = KalshiProvider(provider_cfg)
+    return provider
+
+
+def _kalshi_disabled_payload() -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "healthy": False,
+        "updated_at": datetime.now(NY_TZ).isoformat(),
+        "basis_offset": 0.0,
+        "probability_60m": None,
+        "event_ticker": None,
+        "spx_reference_price": None,
+        "strikes": [],
+    }
+
+
+async def _kalshi_snapshot_loop(path: Path, interval_seconds: float = 10.0) -> None:
+    provider = _build_kalshi_provider()
+    while True:
+        if provider is None or not getattr(provider, "enabled", False):
+            write_json_atomic(path, _kalshi_disabled_payload())
+            await asyncio.sleep(interval_seconds)
+            continue
+        price = _coerce_price_from_state()
+        sentiment = provider.get_sentiment(price) if price is not None else {}
+        strikes = provider._fetch_event_markets()  # noqa: SLF001 - intentionally surfacing full ladder to UI
+        payload: Dict[str, Any] = {
+            "enabled": True,
+            "healthy": bool(getattr(provider, "is_healthy", False)),
+            "updated_at": datetime.now(NY_TZ).isoformat(),
+            "basis_offset": float(getattr(provider, "basis_offset", 0.0) or 0.0),
+            "probability_60m": sentiment.get("probability"),
+            "event_ticker": provider._current_event_ticker(),  # noqa: SLF001 - informational only
+            "spx_reference_price": (float(price) - float(provider.basis_offset)) if price is not None else None,
+            "strikes": strikes if isinstance(strikes, list) else [],
+        }
+        write_json_atomic(path, payload)
+        await asyncio.sleep(interval_seconds)
+
+
+async def _bridge_follow_loop(path: Path) -> None:
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(BRIDGE_SCRIPT),
+        "--follow",
+        "--poll-seconds",
+        "1",
+        "--kalshi-snapshot-path",
+        str(path),
+    )
+    try:
+        await process.wait()
+    finally:
+        if process.returncode is None:
+            process.terminate()
+            await process.wait()
+
+
+async def _run_all() -> None:
+    kalshi_snapshot_path = DEFAULT_KALSHI_SNAPSHOT_PATH
+    tasks = [
+        asyncio.create_task(_kalshi_snapshot_loop(kalshi_snapshot_path)),
+        asyncio.create_task(_bridge_follow_loop(kalshi_snapshot_path)),
+        asyncio.create_task(run_bot()),
+    ]
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+    for task in done:
+        exc = task.exception()
+        if exc is not None:
+            raise exc
 
 
 if __name__ == "__main__":
-    asyncio.run(run_bot())
+    asyncio.run(_run_all())

--- a/montecarlo/Backtest-Simulator-main/FilterlessLiveApp.tsx
+++ b/montecarlo/Backtest-Simulator-main/FilterlessLiveApp.tsx
@@ -27,6 +27,7 @@ import {
 import StatsCard from './components/StatsCard';
 import {
   FilterlessEvent,
+  FilterlessKalshiStrike,
   FilterlessLiveState,
   FilterlessPosition,
   FilterlessStrategyState,
@@ -63,6 +64,7 @@ const EMPTY_STATE: FilterlessLiveState = {
   strategies: [],
   events: [],
   trades: [],
+  kalshi_metrics: null,
 };
 
 function formatMoney(value?: number | null): string {
@@ -202,6 +204,11 @@ function formatBooleanLabel(value?: boolean | null, trueLabel = 'On', falseLabel
 function formatPercent(value?: number | null, digits = 1): string {
   if (value == null || Number.isNaN(value)) return '--';
   return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatStrikeLabel(value?: number | null): string {
+  if (value == null || Number.isNaN(value)) return '--';
+  return value.toFixed(0);
 }
 
 function formatGateSummary(prob?: number | null, threshold?: number | null): string {
@@ -522,6 +529,15 @@ function FilterlessLiveApp() {
   const botStatusColor = heartbeatOk ? 'success' : effectiveBotStatus === 'stale' ? 'warning' : 'danger';
   const dailyPnlColor = (state.bot.risk.daily_pnl || 0) >= 0 ? 'success' : 'danger';
   const openPnlColor = (openPosition?.open_pnl_dollars || 0) >= 0 ? 'success' : 'danger';
+  const kalshiMetrics = state.kalshi_metrics ?? null;
+  const kalshiEnabled = Boolean(kalshiMetrics?.enabled);
+  const kalshiStrikes = useMemo(
+    () =>
+      (kalshiMetrics?.strikes || [])
+        .filter((row): row is FilterlessKalshiStrike => row != null && row.strike != null && row.probability != null)
+        .slice(0, 8),
+    [kalshiMetrics],
+  );
 
   return (
     <div className="min-h-screen bg-background text-neutral-100 pb-16">
@@ -770,6 +786,53 @@ function FilterlessLiveApp() {
             )}
           </Panel>
         </div>
+
+        {kalshiEnabled && (
+          <Panel
+            title="Kalshi Market Sentiment"
+            right={<span className="text-xs text-neutral-500">{formatTimestamp(kalshiMetrics?.updated_at)}</span>}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+              <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-3 py-3">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500">60-Min Probability</p>
+                <p className="mt-1 text-lg font-semibold text-sky-300">{formatPercent(kalshiMetrics?.probability_60m, 2)}</p>
+              </div>
+              <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-3 py-3">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500">Basis Offset</p>
+                <p className="mt-1 text-lg font-semibold text-neutral-100">{formatPrice(kalshiMetrics?.basis_offset)}</p>
+              </div>
+              <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-3 py-3">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500">Event</p>
+                <p className="mt-1 text-sm font-medium text-neutral-200">{kalshiMetrics?.event_ticker || '--'}</p>
+              </div>
+            </div>
+
+            {kalshiStrikes.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="text-left text-neutral-500 border-b border-neutral-800">
+                    <tr>
+                      <th className="py-2 pr-4 font-medium">S&amp;P 500 Strike</th>
+                      <th className="py-2 pr-4 font-medium">Probability</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {kalshiStrikes.map((strike, index) => (
+                      <tr key={`${strike.strike}-${index}`} className="border-b border-neutral-900 last:border-b-0">
+                        <td className="py-2 pr-4 text-neutral-200">{formatStrikeLabel(strike.strike)}</td>
+                        <td className="py-2 pr-4 text-sky-300 font-medium">{formatPercent(strike.probability, 2)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-neutral-800 px-4 py-6 text-center text-sm text-neutral-500">
+                Kalshi strike ladder is not available yet.
+              </div>
+            )}
+          </Panel>
+        )}
 
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
           <Panel title="Recent Events" right={<span className="text-xs text-neutral-500">{state.events.length} items</span>}>

--- a/montecarlo/Backtest-Simulator-main/filterlessLiveTypes.ts
+++ b/montecarlo/Backtest-Simulator-main/filterlessLiveTypes.ts
@@ -105,6 +105,25 @@ export interface FilterlessPricePoint {
   price: number | null;
 }
 
+export interface FilterlessKalshiStrike {
+  strike: number;
+  probability: number;
+  volume?: number | null;
+  status?: string | null;
+  result?: string | null;
+}
+
+export interface FilterlessKalshiMetrics {
+  enabled: boolean;
+  healthy?: boolean;
+  updated_at?: string | null;
+  basis_offset?: number | null;
+  probability_60m?: number | null;
+  event_ticker?: string | null;
+  spx_reference_price?: number | null;
+  strikes: FilterlessKalshiStrike[];
+}
+
 export interface FilterlessLiveState {
   schema_version: number;
   generated_at: string;
@@ -132,4 +151,5 @@ export interface FilterlessLiveState {
   strategies: FilterlessStrategyState[];
   events: FilterlessEvent[];
   trades: FilterlessTrade[];
+  kalshi_metrics?: FilterlessKalshiMetrics | null;
 }

--- a/tools/filterless_dashboard_bridge.py
+++ b/tools/filterless_dashboard_bridge.py
@@ -24,6 +24,7 @@ DEFAULT_LOG_PATH = ROOT / "topstep_live_bot.log"
 DEFAULT_STATE_PATH = ROOT / "bot_state.json"
 DEFAULT_TRADE_FACTORS_PATH = ROOT / "live_trade_factors.csv"
 DEFAULT_OUTPUT_PATH = ROOT / "montecarlo" / "Backtest-Simulator-main" / "public" / "filterless_live_state.json"
+DEFAULT_KALSHI_SNAPSHOT_PATH = ROOT / "kalshi_live_snapshot.json"
 
 
 def _config_float(value: Any, default: float) -> float:
@@ -586,7 +587,64 @@ def build_empty_state(log_path: Path, state_path: Path, trade_factors_path: Path
         "strategies": {strategy_id: strategy_state_template(strategy_id) for strategy_id in STRATEGY_ORDER},
         "events": [],
         "trades": [],
+        "kalshi_metrics": None,
     }
+
+
+def build_kalshi_metrics_from_snapshot(snapshot: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(snapshot, dict):
+        return None
+    enabled = bool(snapshot.get("enabled", False))
+    if not enabled:
+        return {
+            "enabled": False,
+            "healthy": False,
+            "updated_at": snapshot.get("updated_at"),
+            "basis_offset": safe_float(snapshot.get("basis_offset")) or 0.0,
+            "probability_60m": None,
+            "event_ticker": None,
+            "strikes": [],
+        }
+
+    strikes: list[Dict[str, Any]] = []
+    raw_strikes = snapshot.get("strikes")
+    if isinstance(raw_strikes, list):
+        for row in raw_strikes:
+            if not isinstance(row, dict):
+                continue
+            strike = safe_float(row.get("strike"))
+            probability = safe_float(row.get("probability"))
+            if strike is None or probability is None:
+                continue
+            strikes.append(
+                {
+                    "strike": strike,
+                    "probability": probability,
+                    "volume": safe_float(row.get("volume")),
+                    "status": row.get("status"),
+                    "result": row.get("result"),
+                }
+            )
+
+    return {
+        "enabled": True,
+        "healthy": bool(snapshot.get("healthy", True)),
+        "updated_at": snapshot.get("updated_at"),
+        "basis_offset": safe_float(snapshot.get("basis_offset")) or 0.0,
+        "probability_60m": safe_float(snapshot.get("probability_60m")),
+        "event_ticker": snapshot.get("event_ticker"),
+        "spx_reference_price": safe_float(snapshot.get("spx_reference_price")),
+        "strikes": strikes,
+    }
+
+
+def update_state(
+    dashboard: Dict[str, Any],
+    *,
+    kalshi_snapshot: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    dashboard["kalshi_metrics"] = build_kalshi_metrics_from_snapshot(kalshi_snapshot)
+    return dashboard
 
 
 def load_trade_factor_index(path: Path) -> Dict[str, Dict[str, Any]]:
@@ -1164,6 +1222,7 @@ def build_dashboard_state(
     max_events: int,
     max_trades: int,
     max_price_points: int,
+    kalshi_snapshot_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     dashboard = build_empty_state(log_path, state_path, trade_factors_path)
     trade_factor_index = load_trade_factor_index(trade_factors_path)
@@ -1557,6 +1616,15 @@ def build_dashboard_state(
         trade_close_index=trade_close_index,
         daily_tracker=daily_tracker,
     )
+    kalshi_snapshot: Dict[str, Any] = {}
+    if isinstance(kalshi_snapshot_path, Path) and kalshi_snapshot_path.exists():
+        try:
+            parsed = json.loads(kalshi_snapshot_path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                kalshi_snapshot = parsed
+        except (OSError, json.JSONDecodeError):
+            kalshi_snapshot = {}
+    update_state(dashboard, kalshi_snapshot=kalshi_snapshot)
     dashboard["bot"]["risk"]["daily_pnl"] = compute_session_realized_pnl(
         dashboard["trades"],
         trading_day_start_dt,
@@ -1612,6 +1680,7 @@ def run_once(args: argparse.Namespace) -> None:
         max_events=args.max_events,
         max_trades=args.max_trades,
         max_price_points=args.max_price_points,
+        kalshi_snapshot_path=args.kalshi_snapshot_path,
     )
     write_json_atomic(args.output, dashboard)
     if args.output.parent.name == "public":
@@ -1622,7 +1691,7 @@ def run_once(args: argparse.Namespace) -> None:
 
 
 def run_follow(args: argparse.Namespace) -> None:
-    watched = [args.log_path, args.state_path, args.trade_factors_path]
+    watched = [args.log_path, args.state_path, args.trade_factors_path, args.kalshi_snapshot_path]
     last_seen: Optional[tuple[tuple[str, Optional[int], Optional[int]], ...]] = None
     while True:
         current = path_signature(watched)
@@ -1638,6 +1707,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE_PATH)
     parser.add_argument("--trade-factors-path", type=Path, default=DEFAULT_TRADE_FACTORS_PATH)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    parser.add_argument("--kalshi-snapshot-path", type=Path, default=DEFAULT_KALSHI_SNAPSHOT_PATH)
     parser.add_argument("--max-events", type=int, default=80)
     parser.add_argument("--max-trades", type=int, default=30)
     parser.add_argument("--max-price-points", type=int, default=240)


### PR DESCRIPTION
### Motivation
- Surface detailed Kalshi market sentiment (60-minute probability, basis offset and strike ladder) to the filterless live dashboard so operators can see S&P 500 strike probabilities alongside live bot state. 
- Keep behavior safe when Kalshi is disabled by hiding the UI section and avoiding runtime errors.

### Description
- Added Kalshi snapshot support and state plumbing in `tools/filterless_dashboard_bridge.py` by introducing `DEFAULT_KALSHI_SNAPSHOT_PATH`, a `kalshi_metrics` slot on the generated dashboard JSON, `build_kalshi_metrics_from_snapshot(...)`, and an `update_state(...)` helper that attaches parsed Kalshi data into the dashboard payload. The bridge now accepts `--kalshi-snapshot-path` and watches that path in follow mode. 
- Replaced the top-level launcher with `launch_filterless_live.py` that runs three coordinated tasks: `run_bot()`, a Kalshi snapshot loop that writes `kalshi_live_snapshot.json` (pulling `probability_60m`, `basis_offset`, `event_ticker`, and full strike ladder from `KalshiProvider`), and the bridge follow loop which consumes that snapshot so the generated `filterless_live_state.json` contains current Kalshi metrics. The snapshot writer emits a graceful disabled payload when Kalshi is not enabled. 
- Front-end: added types `FilterlessKalshiStrike` and `FilterlessKalshiMetrics` in `filterlessLiveTypes.ts` and extended the live state with an optional `kalshi_metrics` field. Updated `FilterlessLiveApp.tsx` to render a new conditional panel "Kalshi Market Sentiment" showing the 60-minute probability, basis offset, event ticker, and a table of S&P 500 strike probabilities (first N strikes). The panel is only shown when Kalshi is enabled in the snapshot. 

### Testing
- Compiled Python modules: `python -m py_compile tools/filterless_dashboard_bridge.py launch_filterless_live.py` — succeeded. 
- Type-checked front-end: `cd montecarlo/Backtest-Simulator-main && npx tsc --noEmit` — succeeded (only a non-fatal npm env warning from npm).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df58e4b9b8832ab36f11ac951e2d2a)