### PR TITLE
Fix SyntaxError in filterless dashboard bridge update_state

### DIFF
--- a/tools/filterless_dashboard_bridge.py
+++ b/tools/filterless_dashboard_bridge.py
@@ -664,7 +664,6 @@ def update_state(
             "strikes": strikes if isinstance(strikes, list) else [],
         }
         return dashboard
-) -> Dict[str, Any]:
     dashboard["kalshi_metrics"] = build_kalshi_metrics_from_snapshot(kalshi_snapshot)
     return dashboard
 


### PR DESCRIPTION
### Motivation
- Fix a stray parser token that caused a `SyntaxError` in `tools/filterless_dashboard_bridge.py` which prevented the module from importing and caused repeated bridge restarts.

### Description
- Removed an accidental `) -> Dict[str, Any]:` fragment that appeared between the provider branch and the fallback logic inside the `update_state` function in `tools/filterless_dashboard_bridge.py`, restoring the intended control flow and fallback to `build_kalshi_metrics_from_snapshot`.

### Testing
- Successfully ran `python -m py_compile tools/filterless_dashboard_bridge.py` to validate the file compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5f8bffcc832ab026a2ffb8c067c1)