### PR TITLE
Fix truthbrush Cloudflare 1015 crash and Truth Social card blinking

### DIFF
--- a/montecarlo/Backtest-Simulator-main/FilterlessLiveApp.tsx
+++ b/montecarlo/Backtest-Simulator-main/FilterlessLiveApp.tsx
@@ -568,9 +568,9 @@ const StrategyCard: React.FC<{ strategy: FilterlessStrategyState }> = ({ strateg
   ].filter((item): item is string => item !== null);
 
   return (
-    <div className={`rounded-xl border p-5 shadow-sm transition-colors hover:border-neutral-600 ${tone.shell}`}>
+    <div className={`rounded-xl border p-5 shadow-sm hover:border-neutral-600 ${tone.shell}`}>
       <div className="flex items-start justify-between gap-4 mb-4">
-        <div>
+        <div className="min-w-0">
           <div className="flex items-center gap-2">
             <p className="text-lg font-semibold text-neutral-100">{strategy.label}</p>
             <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${tone.badge}`}>
@@ -579,7 +579,7 @@ const StrategyCard: React.FC<{ strategy: FilterlessStrategyState }> = ({ strateg
           </div>
           <p className="text-xs text-neutral-500 mt-1">{formatRelativeTime(strategy.updated_at)}</p>
         </div>
-        <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusChipClasses(strategy.status)}`}>
+        <span className={`shrink-0 min-w-[4.5rem] text-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusChipClasses(strategy.status)}`}>
           {strategy.status.replace('_', ' ')}
         </span>
       </div>

--- a/services/sentiment_service.py
+++ b/services/sentiment_service.py
@@ -215,18 +215,35 @@ class TruthSocialSentimentService:
         lowered = message.lower()
         if "argument of type 'nonetype' is not iterable" in lowered:
             return (
-                "Truth Social returned an empty or HTML response before truthbrush could decode it. "
-                "This is usually a Cloudflare access/rate-limit block, not a dashboard bug."
+                "Truth Social returned an empty or HTML response (Cloudflare access/rate-limit block). "
+                "Polling will resume after backoff."
             )
         if "1015" in lowered or "rate limit" in lowered or "rate limited" in lowered:
             return "Truth Social access is currently rate limited by Cloudflare (Error 1015)."
-        if "cloudflare" in lowered:
+        if "cloudflare" in lowered or "cf-error" in lowered:
             return "Truth Social access is currently blocked by Cloudflare for this client."
+        if any(p in lowered for p in (
+            "expecting value", "jsondecodeerror", "json.decoder",
+            "json decode", "invalid json", "unterminated string",
+        )):
+            return (
+                "Truth Social returned a non-JSON response (likely Cloudflare block). "
+                "Polling will resume after backoff."
+            )
+        if any(p in lowered for p in ("<!doctype", "<html", "<head")):
+            return (
+                "Truth Social returned an HTML error page (likely Cloudflare block). "
+                "Polling will resume after backoff."
+            )
         return message
 
     def _error_backoff_seconds(self, message: str) -> int:
         lowered = str(message or "").lower()
-        if "cloudflare" in lowered or "rate limit" in lowered or "rate limited" in lowered:
+        if any(p in lowered for p in (
+            "cloudflare", "rate limit", "rate limited",
+            "non-json response", "html error page",
+            "empty or html response", "polling will resume",
+        )):
             return max(self.poll_interval * 10, 300)
         return 0
 
@@ -334,7 +351,7 @@ class TruthSocialSentimentService:
                     pinned=False,
                 )
             )
-        except TypeError as exc:
+        except Exception as exc:
             raise RuntimeError(self._normalize_truthbrush_error(exc)) from exc
         if not posts:
             return []

--- a/tools/filterless_dashboard_bridge.py
+++ b/tools/filterless_dashboard_bridge.py
@@ -265,6 +265,15 @@ def normalize_sentiment_error_message(value: Any) -> Optional[str]:
         return "Truth Social access is currently blocked by Cloudflare for this client."
     if "1015" in lowered or "rate limit" in lowered or "rate limited" in lowered:
         return "Truth Social access is currently rate limited by Cloudflare (Error 1015)."
+    if "cloudflare" in lowered or "cf-error" in lowered:
+        return "Truth Social access is currently blocked by Cloudflare for this client."
+    if any(p in lowered for p in (
+        "expecting value", "jsondecodeerror", "json.decoder",
+        "json decode", "invalid json", "unterminated string",
+    )):
+        return "Truth Social returned a non-JSON response (likely Cloudflare block)."
+    if any(p in lowered for p in ("<!doctype", "<html", "<head")):
+        return "Truth Social returned an HTML error page (likely Cloudflare block)."
     return message
 
 


### PR DESCRIPTION
Broadens exception handling in _iter_new_posts from TypeError-only to all exceptions so truthbrush HTML/JSON parse failures no longer crash the sentiment service. Adds detection for JSONDecodeError, HTML content, and cf-error patterns in both the service normalizer and dashboard bridge so Cloudflare blocks always trigger the 5-minute backoff. Removes transition-colors from StrategyCard and stabilizes the status chip width to eliminate visual flickering during state changes.