### PR TITLE
[codex] tighten live flip rules and fix regimeadaptive runtime

### DIFF
--- a/config.py
+++ b/config.py
@@ -4558,7 +4558,10 @@ CONFIG = {
         "RegimeAdaptive": {
             "enabled": True,
             "exit_if_not_green_by": 30,   # If still red after 30 bars, bail
-            "max_profit_crosses": 4       # Max 2 green/red flips before we exit as chop
+            # 2026-04-16 validation: 8 chop flips kept the timeout protection
+            # while materially reducing premature exits on the all-session
+            # wildcard v2 artifact.
+            "max_profit_crosses": 8
         },
         "IntradayDip": {
             "enabled": True,
@@ -4606,6 +4609,19 @@ CONFIG = {
         "require_low_vol_trend": False,
         "require_range_spike": False,
         "enable_signal_reversion": False,
+    },
+
+    # --- Shared Live Opposite-Side Reversal Confirmation ---
+    # Applies to the shared live reverse path across strategies, so a DE3
+    # opposite signal cannot chain with a RegimeAdaptive opposite signal and
+    # immediately flip the whole book. When same_active_trade_family is on,
+    # a strategy family can only reverse its own family's active trade.
+    "LIVE_OPPOSITE_REVERSAL": {
+        "required_confirmations": 3,
+        "window_bars": 3,
+        "require_same_strategy_family": True,
+        "require_same_active_trade_family": True,
+        "require_same_sub_strategy": False,
     },
 
     # --- BREAK-EVEN LOGIC ---

--- a/julie001.py
+++ b/julie001.py
@@ -3658,7 +3658,38 @@ def _resolve_live_early_exit_config(trade: Optional[dict]) -> dict:
         }
     strategy_name = str(trade.get("strategy", "") or "")
     early_exit_cfg = CONFIG.get("EARLY_EXIT", {}).get(strategy_name, {})
-    return early_exit_cfg if isinstance(early_exit_cfg, dict) else {}
+    resolved_cfg = dict(early_exit_cfg) if isinstance(early_exit_cfg, dict) else {}
+
+    explicit_enabled = None
+    explicit_enabled_raw = trade.get("early_exit_enabled")
+    if explicit_enabled_raw is not None:
+        if isinstance(explicit_enabled_raw, str):
+            lowered = explicit_enabled_raw.strip().lower()
+            if lowered in {"1", "true", "yes", "on"}:
+                explicit_enabled = True
+            elif lowered in {"0", "false", "no", "off"}:
+                explicit_enabled = False
+        elif isinstance(explicit_enabled_raw, (bool, int, float)):
+            explicit_enabled = bool(explicit_enabled_raw)
+
+    if explicit_enabled is False:
+        return {}
+    if explicit_enabled is True:
+        resolved_cfg["enabled"] = True
+
+    per_trade_not_green = trade.get("early_exit_exit_if_not_green_by")
+    if per_trade_not_green is not None:
+        resolved_cfg["exit_if_not_green_by"] = int(
+            max(0, _coerce_int(per_trade_not_green, 0))
+        )
+
+    per_trade_crosses = trade.get("early_exit_max_profit_crosses")
+    if per_trade_crosses is not None:
+        resolved_cfg["max_profit_crosses"] = int(
+            max(0, _coerce_int(per_trade_crosses, 0))
+        )
+
+    return resolved_cfg if bool(resolved_cfg.get("enabled", False)) else {}
 
 
 def asia_trend_bias(history_df: pd.DataFrame, cfg: dict) -> Optional[str]:
@@ -3782,6 +3813,89 @@ def format_ui_strategy_slot(
     if sub_strategy:
         return f"{display}:{sub_strategy}"
     return str(display)
+
+
+def get_live_opposite_reversal_family_key(
+    signal: Optional[Dict] = None,
+    *,
+    require_sub_strategy: bool = False,
+) -> Optional[str]:
+    if not isinstance(signal, dict):
+        return None
+    raw_strategy = signal.get("strategy")
+    display, sub_strategy = get_log_strategy_info(raw_strategy, signal)
+    family = str(display or raw_strategy or "").strip()
+    if not family:
+        return None
+    if require_sub_strategy:
+        sub_value = str(
+            sub_strategy
+            or signal.get("sub_strategy")
+            or signal.get("combo_key")
+            or ""
+        ).strip()
+        if sub_value:
+            return f"{family}:{sub_value}"
+    return family
+
+
+def update_live_opposite_reversal_confirmation_state(
+    state: Optional[Dict[str, Any]],
+    signal_payload: Optional[Dict],
+    current_bar_index: int,
+    *,
+    required_confirmations: int,
+    window_bars: int,
+    require_same_strategy_family: bool = True,
+    require_same_sub_strategy: bool = False,
+) -> Tuple[bool, int, Dict[str, Any]]:
+    reset_state = {
+        "count": 0,
+        "side": None,
+        "bar_index": None,
+        "strategy_family": None,
+    }
+    if not isinstance(state, dict):
+        state = dict(reset_state)
+
+    side = None
+    if isinstance(signal_payload, dict):
+        side = _normalize_live_side(signal_payload.get("side"))
+    if side is None:
+        return False, 0, dict(reset_state)
+
+    strategy_family = None
+    if require_same_strategy_family:
+        strategy_family = get_live_opposite_reversal_family_key(
+            signal_payload,
+            require_sub_strategy=require_same_sub_strategy,
+        )
+
+    prior_side = _normalize_live_side(state.get("side"))
+    prior_count = int(state.get("count", 0) or 0)
+    prior_bar_index = _coerce_int(state.get("bar_index"), None)
+    prior_family = str(state.get("strategy_family") or "").strip() or None
+    window_expired = (
+        prior_bar_index is not None
+        and (int(current_bar_index) - prior_bar_index) > int(window_bars)
+    )
+    family_changed = bool(
+        require_same_strategy_family and prior_family != strategy_family
+    )
+
+    if prior_side != side or window_expired or family_changed:
+        new_count = 1
+    else:
+        new_count = prior_count + 1
+
+    next_state = {
+        "count": int(new_count),
+        "side": side,
+        "bar_index": int(current_bar_index),
+        "strategy_family": strategy_family,
+    }
+    confirmed = int(new_count) >= max(1, int(required_confirmations))
+    return confirmed, int(new_count), next_state
 
 
 def parse_continuation_key(strategy_name: Optional[str]) -> Optional[str]:
@@ -6308,12 +6422,27 @@ async def run_bot():
     # Track pending signals for delayed execution
     pending_loose_signals = {}
     last_processed_bar = None
-    opposite_reversal_required = 2
-    opposite_reversal_window_bars = 3
+    opposite_reversal_cfg = CONFIG.get("LIVE_OPPOSITE_REVERSAL", {}) or {}
+    opposite_reversal_required = int(
+        max(1, _coerce_int(opposite_reversal_cfg.get("required_confirmations"), 3))
+    )
+    opposite_reversal_window_bars = int(
+        max(1, _coerce_int(opposite_reversal_cfg.get("window_bars"), 3))
+    )
+    opposite_reversal_require_same_strategy_family = bool(
+        opposite_reversal_cfg.get("require_same_strategy_family", True)
+    )
+    opposite_reversal_require_same_active_trade_family = bool(
+        opposite_reversal_cfg.get("require_same_active_trade_family", False)
+    )
+    opposite_reversal_require_same_sub_strategy = bool(
+        opposite_reversal_cfg.get("require_same_sub_strategy", False)
+    )
     opposite_reversal_state = {
         "count": 0,
         "side": None,
         "bar_index": None,
+        "strategy_family": None,
     }
     pending_impulse_rescues = []
 
@@ -6372,55 +6501,114 @@ async def run_bot():
     def reset_opposite_reversal_state(reason: Optional[str] = None) -> None:
         previous_count = int(opposite_reversal_state.get("count", 0) or 0)
         previous_side = _normalize_live_side(opposite_reversal_state.get("side"))
+        previous_family = str(
+            opposite_reversal_state.get("strategy_family") or ""
+        ).strip()
         if reason and (previous_count > 0 or previous_side):
             logging.info(
-                "Reset opposite reversal confirmation state: %s (count=%s side=%s)",
+                "Reset opposite reversal confirmation state: %s (count=%s side=%s family=%s)",
                 reason,
                 previous_count,
                 previous_side or "NONE",
+                previous_family or "ANY",
             )
         opposite_reversal_state["count"] = 0
         opposite_reversal_state["side"] = None
         opposite_reversal_state["bar_index"] = None
+        opposite_reversal_state["strategy_family"] = None
 
     def note_opposite_reversal_signal(
         signal_payload: Optional[dict],
         current_bar_index: int,
     ) -> Tuple[bool, int]:
-        side = None
-        if isinstance(signal_payload, dict):
-            side = _normalize_live_side(signal_payload.get("side"))
+        confirmed, new_count, next_state = update_live_opposite_reversal_confirmation_state(
+            opposite_reversal_state,
+            signal_payload,
+            current_bar_index,
+            required_confirmations=opposite_reversal_required,
+            window_bars=opposite_reversal_window_bars,
+            require_same_strategy_family=opposite_reversal_require_same_strategy_family,
+            require_same_sub_strategy=opposite_reversal_require_same_sub_strategy,
+        )
+        side = _normalize_live_side(next_state.get("side"))
         if side is None:
             reset_opposite_reversal_state("invalid opposite signal side")
             return False, 0
-
-        prior_side = _normalize_live_side(opposite_reversal_state.get("side"))
-        prior_count = int(opposite_reversal_state.get("count", 0) or 0)
-        prior_bar_index = _coerce_int(opposite_reversal_state.get("bar_index"), None)
-        window_expired = (
-            prior_bar_index is not None
-            and (current_bar_index - prior_bar_index) > opposite_reversal_window_bars
-        )
-
-        if prior_side != side or window_expired:
-            new_count = 1
-        else:
-            new_count = prior_count + 1
-
-        opposite_reversal_state["count"] = int(new_count)
-        opposite_reversal_state["side"] = side
-        opposite_reversal_state["bar_index"] = int(current_bar_index)
-
-        confirmed = new_count >= opposite_reversal_required
+        opposite_reversal_state.update(next_state)
+        strategy_family = str(next_state.get("strategy_family") or "").strip() or "ANY"
         logging.info(
-            "Opposite reversal confirmation: %s %s/%s within %s bars%s",
+            "Opposite reversal confirmation: %s %s/%s within %s bars | family=%s%s",
             side,
             new_count,
             opposite_reversal_required,
             opposite_reversal_window_bars,
+            strategy_family,
             " (confirmed)" if confirmed else "",
         )
         return confirmed, int(new_count)
+
+    def opposite_reversal_matches_active_trade_family(
+        signal_payload: Optional[dict],
+        active_trades_payload: Optional[list[dict]],
+    ) -> bool:
+        if not opposite_reversal_require_same_active_trade_family:
+            return True
+        signal_family = get_live_opposite_reversal_family_key(
+            signal_payload,
+            require_sub_strategy=opposite_reversal_require_same_sub_strategy,
+        )
+        if not signal_family:
+            return True
+        active_families = {
+            str(
+                get_live_opposite_reversal_family_key(
+                    trade,
+                    require_sub_strategy=opposite_reversal_require_same_sub_strategy,
+                )
+                or ""
+            ).strip()
+            for trade in (active_trades_payload or [])
+            if isinstance(trade, dict)
+        }
+        active_families = {family for family in active_families if family}
+        if not active_families:
+            return True
+        return signal_family in active_families
+
+    def log_opposite_reversal_active_trade_family_block(
+        signal_payload: Optional[dict],
+        active_trades_payload: Optional[list[dict]],
+        *,
+        prefix: str = "Holding position",
+    ) -> None:
+        signal_family = (
+            get_live_opposite_reversal_family_key(
+                signal_payload,
+                require_sub_strategy=opposite_reversal_require_same_sub_strategy,
+            )
+            or "UNKNOWN"
+        )
+        active_families = sorted(
+            {
+                str(
+                    get_live_opposite_reversal_family_key(
+                        trade,
+                        require_sub_strategy=opposite_reversal_require_same_sub_strategy,
+                    )
+                    or ""
+                ).strip()
+                for trade in (active_trades_payload or [])
+                if isinstance(trade, dict)
+            }
+            - {""}
+        )
+        active_family_label = ", ".join(active_families) if active_families else "UNKNOWN"
+        logging.info(
+            "%s: opposite signal family %s cannot reverse active family %s",
+            prefix,
+            signal_family,
+            active_family_label,
+        )
 
     def _promote_parallel_trade_if_needed() -> None:
         nonlocal active_trade, parallel_active_trades
@@ -9731,7 +9919,8 @@ async def run_bot():
                                 pending_impulse_rescues.clear()
                                 break
 
-                            old_trades = [dict(trade) for trade in tracked_live_trades()]
+                            current_trades = tracked_live_trades()
+                            old_trades = [dict(trade) for trade in current_trades]
 
                             block_reason = _live_entry_window_block_reason(current_time)
                             if block_reason:
@@ -9741,6 +9930,22 @@ async def run_bot():
                                     current_time,
                                 )
                                 continue
+
+                            if old_trades and not opposite_reversal_matches_active_trade_family(
+                                pending_signal,
+                                current_trades,
+                            ):
+                                reset_opposite_reversal_state(
+                                    "opposite rescue active-trade family mismatch"
+                                )
+                                log_opposite_reversal_active_trade_family_block(
+                                    pending_signal,
+                                    current_trades,
+                                    prefix="Holding position",
+                                )
+                                executed_rescue = True
+                                pending_impulse_rescues.clear()
+                                break
 
                             reverse_state_count = 0
                             if old_trades:
@@ -11758,6 +11963,22 @@ async def run_bot():
                         )
                         continue
                     log_rescue_success()
+                    current_trades = tracked_live_trades()
+                    old_trades = [dict(trade) for trade in current_trades]
+                    if old_trades and not opposite_reversal_matches_active_trade_family(
+                        signal,
+                        current_trades,
+                    ):
+                        reset_opposite_reversal_state(
+                            "opposite active-trade family mismatch"
+                        )
+                        log_opposite_reversal_active_trade_family_block(
+                            signal,
+                            current_trades,
+                            prefix="Holding position",
+                        )
+                        signal_executed = True
+                        break
                     add_strategy_slot(
                         "executed",
                         signal.get("strategy", strat_name),
@@ -11768,8 +11989,6 @@ async def run_bot():
 
                     # ... [Remaining Execution Code same as before] ...
                     # Close and Reverse logic...
-                    old_trades = [dict(trade) for trade in tracked_live_trades()]
-
                     reverse_state_count = 0
                     if old_trades:
                         reverse_confirmed, reverse_state_count = note_opposite_reversal_signal(
@@ -12511,7 +12730,23 @@ async def run_bot():
                                     price=current_price,
                                 )
 
-                                old_trades = [dict(trade) for trade in tracked_live_trades()]
+                                current_trades = tracked_live_trades()
+                                old_trades = [dict(trade) for trade in current_trades]
+                                if old_trades and not opposite_reversal_matches_active_trade_family(
+                                    sig,
+                                    current_trades,
+                                ):
+                                    reset_opposite_reversal_state(
+                                        "loose opposite active-trade family mismatch"
+                                    )
+                                    log_opposite_reversal_active_trade_family_block(
+                                        sig,
+                                        current_trades,
+                                        prefix="Holding position",
+                                    )
+                                    del pending_loose_signals[s_name]
+                                    signal_executed = True
+                                    break
 
                                 reverse_state_count = 0
                                 if old_trades:

--- a/regime_strategy.py
+++ b/regime_strategy.py
@@ -486,6 +486,7 @@ class RegimeAdaptiveStrategy:
         signal = None
         original_signal = None
         revert = False
+        signal_already_finalized = False
         early_exit_enabled = None
         selected_rule_id = None
         selected_sma_fast = sma_fast
@@ -576,6 +577,7 @@ class RegimeAdaptiveStrategy:
             signal = str(chosen["signal"])
             original_signal = str(chosen["original_signal"])
             revert = bool(chosen["revert"])
+            signal_already_finalized = True
             early_exit_enabled = chosen.get("early_exit_enabled")
             selected_rule_id = chosen.get("rule_id")
             selected_sma_fast = float(chosen.get("sma_fast_value", sma_fast))
@@ -610,8 +612,10 @@ class RegimeAdaptiveStrategy:
                 revert = self.enable_signal_reversion and should_revert_signal(ts)
 
         # Apply reversion if needed
-        if revert:
+        if revert and not signal_already_finalized:
             signal = 'SHORT' if signal == 'LONG' else 'LONG'
+            logging.info(f"RegimeAdaptive: Signal REVERTED {original_signal}->{signal} for {combo_key}")
+        elif revert:
             logging.info(f"RegimeAdaptive: Signal REVERTED {original_signal}->{signal} for {combo_key}")
         else:
             logging.info(f"RegimeAdaptive: {signal} signal generated | Combo: {combo_key}")

--- a/tools/run_filterless_flip_policy_compare.py
+++ b/tools/run_filterless_flip_policy_compare.py
@@ -1,0 +1,309 @@
+import argparse
+import concurrent.futures as cf
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import backtest_mes_et as bt
+from config import CONFIG
+
+
+DEFAULT_VARIANTS = {
+    "baseline_count_only_3": {
+        "required_confirmations": 3,
+        "window_bars": 3,
+        "require_same_strategy_family": False,
+        "require_same_active_trade_family": False,
+    },
+    "family_confirm_3": {
+        "required_confirmations": 3,
+        "window_bars": 3,
+        "require_same_strategy_family": True,
+        "require_same_active_trade_family": False,
+    },
+    "same_family_only_3": {
+        "required_confirmations": 3,
+        "window_bars": 3,
+        "require_same_strategy_family": True,
+        "require_same_active_trade_family": True,
+    },
+    "same_family_only_2": {
+        "required_confirmations": 2,
+        "window_bars": 3,
+        "require_same_strategy_family": True,
+        "require_same_active_trade_family": True,
+    },
+}
+
+FILTERLESS_STRATEGIES = {
+    "DynamicEngine3Strategy",
+    "RegimeAdaptiveStrategy",
+    "AetherFlowStrategy",
+}
+
+
+def _resolve_source(path_arg: str) -> Path:
+    path = Path(path_arg).expanduser()
+    if path.is_file():
+        return path.resolve()
+    candidate = (ROOT / path).resolve()
+    if candidate.is_file():
+        return candidate
+    raise SystemExit(f"Data file not found: {path_arg}")
+
+
+def _prepare_symbol_df(
+    source_path: Path,
+    start_time,
+    end_time,
+    symbol_mode: str,
+    symbol_method: str,
+    *,
+    pre_roll_days: int,
+):
+    df = bt.load_csv_cached(source_path, cache_dir=ROOT / "cache", use_cache=True)
+    if df.empty:
+        raise RuntimeError("No rows found in the source file.")
+
+    selection_start = start_time - pd.Timedelta(days=max(0, int(pre_roll_days)))
+    selection_start = selection_start.replace(hour=0, minute=0, second=0, microsecond=0)
+    source_df = df[(df.index >= selection_start) & (df.index <= end_time)]
+    if source_df.empty:
+        raise RuntimeError("No rows found inside the requested symbol-selection window.")
+
+    symbol = None
+    symbol_distribution = {}
+    symbol_df = source_df
+    if "symbol" in source_df.columns:
+        if symbol_mode != "single":
+            symbol_df, auto_label, _ = bt.apply_symbol_mode(source_df, symbol_mode, symbol_method)
+            if symbol_df.empty:
+                raise RuntimeError("No rows found after auto symbol selection.")
+            selected_range_df = symbol_df[(symbol_df.index >= start_time) & (symbol_df.index <= end_time)]
+            if selected_range_df.empty:
+                raise RuntimeError("No rows found in selected range after auto symbol selection.")
+            symbol_distribution = selected_range_df["symbol"].value_counts().to_dict()
+            symbol = auto_label
+        else:
+            preferred_symbol = bt.CONFIG.get("TARGET_SYMBOL")
+            symbol = bt.choose_symbol(source_df, preferred_symbol)
+            symbol_df = source_df[source_df["symbol"] == symbol]
+            if symbol_df.empty:
+                raise RuntimeError("No rows found for selected symbol.")
+            selected_range_df = symbol_df[(symbol_df.index >= start_time) & (symbol_df.index <= end_time)]
+            if selected_range_df.empty:
+                raise RuntimeError("No rows found in selected range for selected symbol.")
+            symbol_distribution = selected_range_df["symbol"].value_counts().to_dict()
+
+        symbol_df = symbol_df.drop(columns=["symbol"], errors="ignore")
+    else:
+        selected_range_df = source_df[(source_df.index >= start_time) & (source_df.index <= end_time)]
+        if selected_range_df.empty:
+            raise RuntimeError("No rows found in the selected range.")
+        symbol = "AUTO"
+
+    source_attrs = getattr(source_df, "attrs", {}) or {}
+    symbol_df = bt.attach_backtest_symbol_context(
+        symbol_df,
+        symbol,
+        symbol_mode,
+        source_key=source_attrs.get("source_cache_key"),
+        source_label=source_attrs.get("source_label"),
+        source_path=source_attrs.get("source_path"),
+    )
+    return symbol_df, symbol, symbol_distribution
+
+
+def _run_variant(
+    *,
+    source_path: str,
+    start_raw: str,
+    end_raw: str,
+    symbol_mode: str,
+    symbol_method: str,
+    pre_roll_days: int,
+    variant_name: str,
+    variant_cfg: dict,
+    worker_count: int,
+) -> dict:
+    orig_live_opp = copy.deepcopy(CONFIG.get("LIVE_OPPOSITE_REVERSAL", {}) or {})
+    orig_gemini = copy.deepcopy(CONFIG.get("GEMINI", {}) or {})
+    orig_live_report = copy.deepcopy(CONFIG.get("BACKTEST_LIVE_REPORT", {}) or {})
+    orig_console_progress = CONFIG.get("BACKTEST_CONSOLE_PROGRESS", True)
+    orig_workers = CONFIG.get("BACKTEST_WORKERS", 6)
+
+    try:
+        CONFIG["LIVE_OPPOSITE_REVERSAL"] = dict(variant_cfg)
+        CONFIG.setdefault("GEMINI", {})["enabled"] = False
+        CONFIG.setdefault("BACKTEST_LIVE_REPORT", {})["enabled"] = False
+        CONFIG["BACKTEST_CONSOLE_PROGRESS"] = False
+        CONFIG["BACKTEST_WORKERS"] = int(max(1, worker_count))
+
+        start_time = bt.parse_user_datetime(start_raw, bt.NY_TZ, is_end=False)
+        end_time = bt.parse_user_datetime(end_raw, bt.NY_TZ, is_end=True)
+        symbol_df, symbol, symbol_distribution = _prepare_symbol_df(
+            Path(source_path),
+            start_time,
+            end_time,
+            symbol_mode,
+            symbol_method,
+            pre_roll_days=pre_roll_days,
+        )
+
+        stats = bt.run_backtest(
+            symbol_df,
+            start_time,
+            end_time,
+            enabled_strategies=set(FILTERLESS_STRATEGIES),
+            enabled_filters=set(),
+        )
+        return {
+            "variant": variant_name,
+            "config": dict(variant_cfg),
+            "window": {
+                "start": start_time.isoformat(),
+                "end": end_time.isoformat(),
+            },
+            "symbol": symbol,
+            "symbol_distribution": symbol_distribution,
+            "equity": stats.get("equity"),
+            "trades": stats.get("trades"),
+            "wins": stats.get("wins"),
+            "losses": stats.get("losses"),
+            "winrate": stats.get("winrate"),
+            "profit_factor": stats.get("profit_factor"),
+            "max_drawdown": stats.get("max_drawdown"),
+            "avg_trade_net": stats.get("avg_trade_net"),
+            "strategy_stats": stats.get("strategy_stats", {}),
+            "exit_reason_counts": stats.get("exit_reason_counts", {}),
+            "selection": stats.get("selection", {}),
+        }
+    finally:
+        CONFIG["LIVE_OPPOSITE_REVERSAL"] = orig_live_opp
+        CONFIG["GEMINI"] = orig_gemini
+        CONFIG["BACKTEST_LIVE_REPORT"] = orig_live_report
+        CONFIG["BACKTEST_CONSOLE_PROGRESS"] = orig_console_progress
+        CONFIG["BACKTEST_WORKERS"] = orig_workers
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare shared flip/reversal policies on the current filterless "
+            "DE3 + RegimeAdaptive + AetherFlow stack using one process per variant."
+        )
+    )
+    parser.add_argument("--source", default="es_master_outrights.parquet")
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--symbol-mode", default="auto_by_day")
+    parser.add_argument("--symbol-method", default="volume")
+    parser.add_argument("--pre-roll-days", type=int, default=180)
+    parser.add_argument(
+        "--variant",
+        action="append",
+        default=[],
+        help="Repeatable variant name. Defaults to all built-in variants.",
+    )
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=2,
+        help="Maximum number of variant processes to run at once.",
+    )
+    parser.add_argument(
+        "--worker-count",
+        type=int,
+        default=1,
+        help="BACKTEST_WORKERS to give each variant process.",
+    )
+    parser.add_argument(
+        "--out",
+        default="reports/combined_flip_policy_parallel/summary.json",
+    )
+    args = parser.parse_args()
+
+    source_path = _resolve_source(str(args.source))
+    selected_variant_names = list(args.variant or [])
+    if not selected_variant_names:
+        selected_variant_names = list(DEFAULT_VARIANTS.keys())
+
+    variants = {
+        name: dict(DEFAULT_VARIANTS[name])
+        for name in selected_variant_names
+        if name in DEFAULT_VARIANTS
+    }
+    if not variants:
+        raise SystemExit("No valid variants selected.")
+
+    out_path = Path(args.out).expanduser()
+    if not out_path.is_absolute():
+        out_path = (ROOT / out_path).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    max_parallel = max(1, min(int(args.max_parallel), len(variants)))
+    summary = {
+        "created_at": pd.Timestamp.now(tz="America/New_York").isoformat(),
+        "source_path": str(source_path),
+        "selected_strategies": sorted(FILTERLESS_STRATEGIES),
+        "selected_filters": [],
+        "window": {"start": str(args.start), "end": str(args.end)},
+        "symbol_mode": str(args.symbol_mode),
+        "symbol_method": str(args.symbol_method),
+        "pre_roll_days": int(args.pre_roll_days),
+        "max_parallel": int(max_parallel),
+        "worker_count_per_variant": int(max(1, int(args.worker_count))),
+        "variants": {},
+    }
+
+    def write_summary() -> None:
+        out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    write_summary()
+
+    future_map = {}
+    with cf.ProcessPoolExecutor(max_workers=max_parallel) as executor:
+        for variant_name, variant_cfg in variants.items():
+            future = executor.submit(
+                _run_variant,
+                source_path=str(source_path),
+                start_raw=str(args.start),
+                end_raw=str(args.end),
+                symbol_mode=str(args.symbol_mode),
+                symbol_method=str(args.symbol_method),
+                pre_roll_days=int(args.pre_roll_days),
+                variant_name=str(variant_name),
+                variant_cfg=dict(variant_cfg),
+                worker_count=int(args.worker_count),
+            )
+            future_map[future] = variant_name
+
+        for future in cf.as_completed(future_map):
+            variant_name = future_map[future]
+            try:
+                result = future.result()
+            except Exception as exc:
+                summary["variants"][variant_name] = {"error": str(exc)}
+            else:
+                summary["variants"][variant_name] = result
+                print(
+                    f"{variant_name}: equity={result.get('equity')} "
+                    f"trades={result.get('trades')} dd={result.get('max_drawdown')} "
+                    f"pf={result.get('profit_factor')}",
+                    flush=True,
+                )
+            write_summary()
+
+    print(f"Wrote summary to {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- tighten shared live opposite-side reversal handling so a strategy family can only reverse its own active family after 3 confirmations
- fix RegimeAdaptive reversed-signal handling so already-finalized reversed signals are not flipped a second time
- add the filterless DE3 + RegimeAdaptive + AetherFlow flip-policy comparison harness used to validate the new live reversal rule
- raise RegimeAdaptive live early-exit chop tolerance from 4 to 8 profit crosses

## Validation
- `python -m py_compile config.py julie001.py regime_strategy.py tools/run_filterless_flip_policy_compare.py`
- 2025 filterless combined-stack compare: `same_family_only_3` beat `baseline_count_only_3`
- fresh 2026-01-01 through 2026-01-26 filterless combined-stack compare: `same_family_only_3` beat `baseline_count_only_3`

## Scope
- strategy/runtime only
- no UI or dashboard assets
