### PR TITLE
Add backtest tooling workflows

### DIFF
--- a/tools/build_aetherflow_multi_expert_router.py
+++ b/tools/build_aetherflow_multi_expert_router.py
@@ -1,0 +1,534 @@
+import argparse
+import json
+import math
+import pickle
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.metrics import roc_auc_score
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from aetherflow_features import ensure_feature_columns  # noqa: E402
+from aetherflow_model_bundle import (  # noqa: E402
+    ROUTED_ENSEMBLE_DEFAULT_ROUTER_FEATURE_COLUMNS,
+    _router_activation_mask,
+    build_routed_ensemble_router_frame,
+    bundle_feature_columns,
+    make_routed_ensemble_bundle,
+    normalize_model_bundle,
+    predict_bundle_probabilities,
+)
+from aetherflow_strategy import augment_aetherflow_phase_features  # noqa: E402
+
+
+def _resolve_path(path_text: str, default_relative: str = "") -> Path:
+    raw = str(path_text or "").strip()
+    path = Path(raw).expanduser() if raw else (ROOT / default_relative)
+    if not path.is_absolute():
+        path = ROOT / path
+    return path.resolve()
+
+
+def _clip_probs(values: np.ndarray) -> np.ndarray:
+    return np.clip(np.asarray(values, dtype=float), 1e-6, 1.0 - 1e-6)
+
+
+def _logloss_per_row(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    y = np.asarray(y_true, dtype=float)
+    p = _clip_probs(prob)
+    return -(y * np.log(p) + (1.0 - y) * np.log(1.0 - p))
+
+
+def _logloss(y_true: np.ndarray, prob: np.ndarray) -> float:
+    return float(np.mean(_logloss_per_row(y_true, prob))) if len(y_true) else float("nan")
+
+
+def _brier(y_true: np.ndarray, prob: np.ndarray) -> float:
+    y = np.asarray(y_true, dtype=float)
+    p = np.asarray(prob, dtype=float)
+    return float(np.mean(np.square(p - y))) if len(y_true) else float("nan")
+
+
+def _auc(y_true: np.ndarray, prob: np.ndarray) -> float:
+    y = np.asarray(y_true, dtype=int)
+    if len(y) == 0 or np.unique(y).size < 2:
+        return float("nan")
+    return float(roc_auc_score(y, np.asarray(prob, dtype=float)))
+
+
+def _predict_in_batches(bundle: dict[str, Any], features: pd.DataFrame, batch_size: int) -> np.ndarray:
+    if features.empty:
+        return np.asarray([], dtype=float)
+    outputs: list[np.ndarray] = []
+    for start in range(0, len(features), max(1, int(batch_size))):
+        batch = features.iloc[start : start + int(batch_size)]
+        outputs.append(np.asarray(predict_bundle_probabilities(bundle, batch), dtype=float))
+    return np.concatenate(outputs, axis=0) if outputs else np.asarray([], dtype=float)
+
+
+def _split_mask(index: pd.DatetimeIndex, start: str | None, end: str | None) -> np.ndarray:
+    mask = np.ones(len(index), dtype=bool)
+    if start:
+        mask &= index >= pd.Timestamp(start, tz=index.tz)
+    if end:
+        mask &= index <= pd.Timestamp(end, tz=index.tz)
+    return mask
+
+
+def _metrics_payload(y_true: np.ndarray, prob: np.ndarray) -> dict[str, Any]:
+    return {
+        "rows": int(len(y_true)),
+        "positive_rate": float(np.mean(np.asarray(y_true, dtype=float))) if len(y_true) else float("nan"),
+        "logloss": _logloss(y_true, prob),
+        "brier": _brier(y_true, prob),
+        "auc": _auc(y_true, prob),
+        "prob_mean": float(np.mean(np.asarray(prob, dtype=float))) if len(y_true) else float("nan"),
+    }
+
+
+def _compute_router_targets(
+    *,
+    labels: np.ndarray,
+    net_points: np.ndarray,
+    expert_probabilities: dict[str, np.ndarray],
+    expert_names: list[str],
+    active_matrix: np.ndarray,
+    target_mode: str,
+    utility_center_prob: float,
+) -> tuple[np.ndarray, np.ndarray, dict[str, Any]]:
+    loss_matrix = np.full((len(labels), len(expert_names)), np.inf, dtype=float)
+    for idx, expert_name in enumerate(expert_names):
+        probs = np.asarray(expert_probabilities[expert_name], dtype=float)
+        row_loss = _logloss_per_row(labels, probs)
+        loss_matrix[:, idx] = np.where(active_matrix[:, idx], row_loss, np.inf)
+
+    mode_key = str(target_mode or "best_expert_logloss").strip().lower()
+    diagnostics: dict[str, Any] = {"target_mode": mode_key}
+    if mode_key == "best_expert_trade_utility":
+        center_prob = float(np.clip(float(utility_center_prob), 0.05, 0.95))
+        pnl_scale = np.sqrt(np.maximum(np.abs(np.asarray(net_points, dtype=float)), 0.0))
+        pnl_sign = np.sign(np.asarray(net_points, dtype=float))
+        utility_matrix = np.full((len(labels), len(expert_names)), -np.inf, dtype=float)
+        for idx, expert_name in enumerate(expert_names):
+            probs = np.asarray(expert_probabilities[expert_name], dtype=float)
+            centered = probs - center_prob
+            utility = (pnl_sign * pnl_scale * centered) + (-1e-4 * loss_matrix[:, idx])
+            utility_matrix[:, idx] = np.where(active_matrix[:, idx], utility, -np.inf)
+        target_index = np.argmax(utility_matrix, axis=1).astype(int)
+        sorted_utilities = np.sort(utility_matrix, axis=1)
+        best_utility = sorted_utilities[:, -1]
+        if len(expert_names) > 1:
+            second_utility = sorted_utilities[:, -2]
+            second_utility = np.where(np.isfinite(second_utility), second_utility, best_utility)
+        else:
+            second_utility = best_utility
+        sample_weight = np.maximum(best_utility - second_utility, 0.01)
+        diagnostics["utility_center_prob"] = center_prob
+        diagnostics["target_score_summary"] = {
+            "mean_best_utility": float(np.mean(best_utility)) if len(best_utility) else float("nan"),
+            "mean_gap": float(np.mean(best_utility - second_utility)) if len(best_utility) else float("nan"),
+        }
+        return target_index, sample_weight, diagnostics
+
+    target_index = np.argmin(loss_matrix, axis=1).astype(int)
+    sorted_losses = np.sort(loss_matrix, axis=1)
+    best_loss = sorted_losses[:, 0]
+    if len(expert_names) > 1:
+        second_loss = sorted_losses[:, 1]
+        second_loss = np.where(np.isfinite(second_loss), second_loss, best_loss)
+    else:
+        second_loss = best_loss
+    sample_weight = np.maximum(second_loss - best_loss, 0.01)
+    diagnostics["target_score_summary"] = {
+        "mean_best_logloss": float(np.mean(best_loss)) if len(best_loss) else float("nan"),
+        "mean_gap": float(np.mean(second_loss - best_loss)) if len(best_loss) else float("nan"),
+    }
+    return target_index, sample_weight, diagnostics
+
+
+def _fit_router(
+    x_train: pd.DataFrame,
+    y_train: np.ndarray,
+    *,
+    sample_weight: np.ndarray,
+    max_depth: int,
+    max_iter: int,
+    learning_rate: float,
+    min_samples_leaf: int,
+    random_state: int,
+) -> HistGradientBoostingClassifier:
+    model = HistGradientBoostingClassifier(
+        loss="log_loss",
+        learning_rate=float(learning_rate),
+        max_iter=int(max_iter),
+        max_depth=int(max_depth),
+        min_samples_leaf=int(min_samples_leaf),
+        l2_regularization=0.05,
+        random_state=int(random_state),
+    )
+    model.fit(x_train, y_train, sample_weight=sample_weight)
+    return model
+
+
+def _load_json_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load JSON payload: {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object at {path}")
+    return payload
+
+
+def _load_expert_specs(path: Path) -> tuple[list[dict[str, Any]], str]:
+    payload = _load_json_payload(path)
+    fallback_expert = str(payload.get("fallback_expert", "") or "").strip()
+    raw_experts = payload.get("experts", []) or []
+    if not isinstance(raw_experts, list) or not raw_experts:
+        raise RuntimeError(f"No experts found in {path}")
+    experts: list[dict[str, Any]] = []
+    for item in raw_experts:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", "") or "").strip()
+        model_file = str(item.get("model_file", "") or "").strip()
+        thresholds_file = str(item.get("thresholds_file", "") or "").strip()
+        if not name or not model_file or not thresholds_file:
+            continue
+        activation_rules = item.get("activation_rules", []) or []
+        if not isinstance(activation_rules, list):
+            activation_rules = []
+        override = item.get("override")
+        if not isinstance(override, dict):
+            override = None
+        experts.append(
+            {
+                "name": name,
+                "model_path": _resolve_path(model_file),
+                "thresholds_path": _resolve_path(thresholds_file),
+                "activation_rules": [dict(rule) for rule in activation_rules if isinstance(rule, dict)],
+                "override": dict(override or {}) if isinstance(override, dict) else None,
+            }
+        )
+    if not experts:
+        raise RuntimeError(f"No usable experts in {path}")
+    if not fallback_expert:
+        fallback_expert = str(experts[0]["name"])
+    return experts, fallback_expert
+
+
+def _frame_to_jsonable(frame: pd.DataFrame) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for _, row in frame.iterrows():
+        payload: dict[str, Any] = {}
+        for key, value in row.items():
+            if pd.isna(value):
+                payload[str(key)] = None
+            elif isinstance(value, (np.integer,)):
+                payload[str(key)] = int(value)
+            elif isinstance(value, (np.floating,)):
+                payload[str(key)] = float(value)
+            else:
+                payload[str(key)] = value
+        rows.append(payload)
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a multi-expert AetherFlow routed ensemble artifact.")
+    parser.add_argument("--experts-file", required=True)
+    parser.add_argument("--features-parquet", required=True)
+    parser.add_argument("--output-model-file", required=True)
+    parser.add_argument("--output-thresholds-file", required=True)
+    parser.add_argument("--output-metrics-file", required=True)
+    parser.add_argument("--train-end", default="2024-12-31 23:59")
+    parser.add_argument("--validation-end", default="2025-12-31 23:59")
+    parser.add_argument("--refit-through-validation", action="store_true")
+    parser.add_argument("--batch-size", type=int, default=50000)
+    parser.add_argument("--max-depth", type=int, default=4)
+    parser.add_argument("--max-iter", type=int, default=250)
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--min-samples-leaf", type=int, default=256)
+    parser.add_argument("--random-state", type=int, default=1337)
+    parser.add_argument("--router-mode", choices=["soft_blend", "hard_route"], default="soft_blend")
+    parser.add_argument("--router-min-top-prob", type=float, default=0.0)
+    parser.add_argument("--router-min-top-gap", type=float, default=0.0)
+    parser.add_argument(
+        "--router-target-mode",
+        choices=["best_expert_logloss", "best_expert_trade_utility"],
+        default="best_expert_logloss",
+    )
+    parser.add_argument("--utility-center-prob", type=float, default=0.55)
+    args = parser.parse_args()
+
+    experts_file = _resolve_path(str(args.experts_file))
+    features_path = _resolve_path(str(args.features_parquet))
+    output_model_path = _resolve_path(str(args.output_model_file))
+    output_thresholds_path = _resolve_path(str(args.output_thresholds_file))
+    output_metrics_path = _resolve_path(str(args.output_metrics_file))
+
+    expert_specs, fallback_expert = _load_expert_specs(experts_file)
+    output_model_path.parent.mkdir(parents=True, exist_ok=True)
+    output_thresholds_path.parent.mkdir(parents=True, exist_ok=True)
+    output_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+
+    experts: list[dict[str, Any]] = []
+    for spec in expert_specs:
+        with spec["model_path"].open("rb") as fh:
+            bundle = normalize_model_bundle(pickle.load(fh))
+        thresholds = _load_json_payload(spec["thresholds_path"])
+        experts.append(
+            {
+                "name": spec["name"],
+                "bundle": bundle,
+                "thresholds": thresholds,
+                "activation_rules": list(spec.get("activation_rules", []) or []),
+                "override": dict(spec.get("override") or {}) if isinstance(spec.get("override"), dict) else None,
+                "model_path": spec["model_path"],
+                "thresholds_path": spec["thresholds_path"],
+            }
+        )
+
+    stable_thresholds = dict(experts[0]["thresholds"] or {})
+    live_families = [
+        str(item).strip()
+        for item in (stable_thresholds.get("allowed_setup_families", []) or [])
+        if str(item).strip()
+    ]
+    blocked_regimes = {
+        str(item).strip().upper()
+        for item in (stable_thresholds.get("hazard_block_regimes", []) or [])
+        if str(item).strip()
+    }
+
+    data = pd.read_parquet(features_path)
+    data = ensure_feature_columns(data)
+    data = data.replace([np.inf, -np.inf], np.nan)
+    data = data.dropna(subset=["label", "net_points"]).copy()
+    data["label"] = pd.to_numeric(data["label"], errors="coerce").fillna(0).astype(int)
+    data = data.sort_index()
+    data = augment_aetherflow_phase_features(data)
+    if live_families:
+        data = data.loc[data["setup_family"].astype(str).isin(live_families)].copy()
+    if blocked_regimes and "manifold_regime_name" in data.columns:
+        data = data.loc[~data["manifold_regime_name"].astype(str).str.upper().isin(sorted(blocked_regimes))].copy()
+    if data.empty:
+        raise RuntimeError("No multi-expert training rows remain after live-family filtering.")
+
+    labels = data["label"].to_numpy(dtype=int)
+    net_points = pd.to_numeric(data["net_points"], errors="coerce").fillna(0.0).to_numpy(dtype=float)
+    expert_probabilities: dict[str, np.ndarray] = {}
+    active_matrix = np.ones((len(data), len(experts)), dtype=bool)
+    for idx, expert in enumerate(experts):
+        expert_probabilities[expert["name"]] = _predict_in_batches(expert["bundle"], data, int(args.batch_size))
+        rules = list(expert.get("activation_rules", []) or [])
+        if rules:
+            active_matrix[:, idx] = _router_activation_mask(data, rules)
+
+    expert_names = [expert["name"] for expert in experts]
+    target_index, sample_weight, target_diagnostics = _compute_router_targets(
+        labels=labels,
+        net_points=net_points,
+        expert_probabilities=expert_probabilities,
+        expert_names=expert_names,
+        active_matrix=active_matrix,
+        target_mode=str(args.router_target_mode),
+        utility_center_prob=float(args.utility_center_prob),
+    )
+
+    router_frame = build_routed_ensemble_router_frame(data, expert_probabilities)
+    router_feature_columns = [
+        col for col in ROUTED_ENSEMBLE_DEFAULT_ROUTER_FEATURE_COLUMNS if col in router_frame.columns
+    ] or list(router_frame.columns)
+    router_frame = router_frame.reindex(columns=router_feature_columns, fill_value=0.0).replace([np.inf, -np.inf], np.nan).fillna(0.0)
+
+    index = pd.DatetimeIndex(data.index)
+    train_mask = _split_mask(index, None, str(args.train_end))
+    val_mask = _split_mask(index, str(pd.Timestamp(args.train_end) + pd.Timedelta(minutes=1)), str(args.validation_end))
+    post_val_mask = _split_mask(index, str(pd.Timestamp(args.validation_end) + pd.Timedelta(minutes=1)), None)
+    jan_2026_mask = _split_mask(index, "2026-01-01", "2026-01-26 23:59")
+    fresh_2026_mask = _split_mask(index, "2026-01-27", None)
+    april_2026_mask = _split_mask(index, "2026-04-01", None)
+
+    if not bool(train_mask.any()):
+        raise RuntimeError("Router train split is empty.")
+    if not bool(val_mask.any()):
+        raise RuntimeError("Router validation split is empty.")
+
+    router_model = _fit_router(
+        router_frame.loc[train_mask],
+        target_index[train_mask],
+        sample_weight=sample_weight[train_mask],
+        max_depth=int(args.max_depth),
+        max_iter=int(args.max_iter),
+        learning_rate=float(args.learning_rate),
+        min_samples_leaf=int(args.min_samples_leaf),
+        random_state=int(args.random_state),
+    )
+
+    final_router_model = router_model
+    effective_fit_end = str(args.train_end)
+    if bool(args.refit_through_validation):
+        refit_mask = train_mask | val_mask
+        final_router_model = _fit_router(
+            router_frame.loc[refit_mask],
+            target_index[refit_mask],
+            sample_weight=sample_weight[refit_mask],
+            max_depth=int(args.max_depth),
+            max_iter=int(args.max_iter),
+            learning_rate=float(args.learning_rate),
+            min_samples_leaf=int(args.min_samples_leaf),
+            random_state=int(args.random_state),
+        )
+        effective_fit_end = str(args.validation_end)
+
+    bundle = make_routed_ensemble_bundle(
+        experts=[
+            {
+                "name": expert["name"],
+                "bundle": expert["bundle"],
+                "activation_rules": expert.get("activation_rules", []),
+                "override": expert.get("override"),
+            }
+            for expert in experts
+        ],
+        router_model=final_router_model,
+        router_feature_columns=router_feature_columns,
+        threshold=float(stable_thresholds.get("threshold", experts[0]["bundle"].get("threshold", 0.54)) or 0.54),
+        trained_at=pd.Timestamp.now("UTC").isoformat(),
+        walkforward_fold="multi_expert_router_2011_2025",
+        router_mode=str(args.router_mode),
+        router_weight_floor=0.0,
+        router_weight_ceiling=1.0,
+        router_training_report={
+            "train_end": str(args.train_end),
+            "validation_end": str(args.validation_end),
+            "effective_router_fit_end": effective_fit_end,
+            "target_mode": str(args.router_target_mode),
+            "utility_center_prob": float(args.utility_center_prob),
+            "target_diagnostics": target_diagnostics,
+            "experts_file": str(experts_file),
+        },
+        router_fallback_expert=fallback_expert,
+        router_min_top_prob=float(args.router_min_top_prob),
+        router_min_top_gap=float(args.router_min_top_gap),
+    )
+    normalized_bundle = normalize_model_bundle(bundle)
+    routed_prob = _predict_in_batches(normalized_bundle, data, int(args.batch_size))
+
+    with output_model_path.open("wb") as fh:
+        pickle.dump(bundle, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+    thresholds_payload = {
+        "threshold": float(stable_thresholds.get("threshold", normalized_bundle.get("threshold", 0.54)) or 0.54),
+        "bundle_design": str(normalized_bundle.get("bundle_design", "routed_ensemble") or "routed_ensemble"),
+        "feature_columns": bundle_feature_columns(normalized_bundle),
+        "router_mode": str(args.router_mode),
+        "router_min_top_prob": float(args.router_min_top_prob),
+        "router_min_top_gap": float(args.router_min_top_gap),
+        "router_target_mode": str(args.router_target_mode),
+        "utility_center_prob": float(args.utility_center_prob),
+        "router_feature_columns": list(router_feature_columns),
+        "router_fallback_expert": str(fallback_expert),
+        "allowed_setup_families": live_families,
+        "hazard_block_regimes": sorted(blocked_regimes),
+        "experts": [
+            {
+                "name": expert["name"],
+                "model_file": str(expert["model_path"]),
+                "thresholds_file": str(expert["thresholds_path"]),
+                "activation_rules": list(expert.get("activation_rules", []) or []),
+                "override": dict(expert.get("override") or {}) if isinstance(expert.get("override"), dict) else None,
+                "bundle_design": str(expert["bundle"].get("bundle_design", "single") or "single"),
+                "conditional_models": len(expert["bundle"].get("conditional_models", []) or []),
+            }
+            for expert in experts
+        ],
+        "packaged_at": pd.Timestamp.now("UTC").isoformat(),
+    }
+    output_thresholds_path.write_text(json.dumps(thresholds_payload, indent=2), encoding="utf-8")
+
+    split_masks = {
+        "train_2011_2024": train_mask,
+        "validation_2025": val_mask,
+        "holdout_post_validation": post_val_mask,
+        "jan_2026": jan_2026_mask,
+        "fresh_2026_post_jan26": fresh_2026_mask,
+        "april_2026": april_2026_mask,
+    }
+    split_metrics: dict[str, Any] = {}
+    for split_name, mask in split_masks.items():
+        if not bool(mask.any()):
+            continue
+        split_metrics[split_name] = {
+            expert["name"]: _metrics_payload(labels[mask], expert_probabilities[expert["name"]][mask])
+            for expert in experts
+        }
+        split_metrics[split_name]["routed"] = _metrics_payload(labels[mask], routed_prob[mask])
+
+    target_shares = {}
+    for idx, expert in enumerate(experts):
+        target_shares[expert["name"]] = {
+            "all": float(np.mean(target_index == idx)),
+            "train": float(np.mean(target_index[train_mask] == idx)) if bool(train_mask.any()) else None,
+            "validation": float(np.mean(target_index[val_mask] == idx)) if bool(val_mask.any()) else None,
+        }
+
+    metrics_payload = {
+        "artifact": {
+            "model_file": str(output_model_path),
+            "thresholds_file": str(output_thresholds_path),
+            "features_parquet": str(features_path),
+        },
+        "training_rows": int(len(data)),
+        "training_families": live_families,
+        "blocked_regimes": sorted(blocked_regimes),
+        "router": {
+            "feature_columns": list(router_feature_columns),
+            "fit_end": effective_fit_end,
+            "fallback_expert": str(fallback_expert),
+            "router_mode": str(args.router_mode),
+            "router_min_top_prob": float(args.router_min_top_prob),
+            "router_min_top_gap": float(args.router_min_top_gap),
+            "router_target_mode": str(args.router_target_mode),
+            "utility_center_prob": float(args.utility_center_prob),
+            "target_shares": target_shares,
+            "target_diagnostics": target_diagnostics,
+            "params": {
+                "max_depth": int(args.max_depth),
+                "max_iter": int(args.max_iter),
+                "learning_rate": float(args.learning_rate),
+                "min_samples_leaf": int(args.min_samples_leaf),
+                "random_state": int(args.random_state),
+            },
+        },
+        "split_metrics": split_metrics,
+    }
+    output_metrics_path.write_text(json.dumps(metrics_payload, indent=2), encoding="utf-8")
+
+    preview = pd.DataFrame(
+        [
+            {
+                "expert": expert["name"],
+                "target_share_all": target_shares[expert["name"]]["all"],
+                "target_share_train": target_shares[expert["name"]]["train"],
+                "target_share_validation": target_shares[expert["name"]]["validation"],
+            }
+            for expert in experts
+        ]
+    )
+    print(f"output_model={output_model_path}")
+    print(f"output_thresholds={output_thresholds_path}")
+    print(f"output_metrics={output_metrics_path}")
+    print("target_share_summary=" + json.dumps(_frame_to_jsonable(preview), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build_aetherflow_routed_ensemble.py
+++ b/tools/build_aetherflow_routed_ensemble.py
@@ -1,0 +1,498 @@
+import argparse
+import json
+import math
+import pickle
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.metrics import roc_auc_score
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from aetherflow_features import ensure_feature_columns  # noqa: E402
+from aetherflow_model_bundle import (  # noqa: E402
+    ROUTED_ENSEMBLE_DEFAULT_ROUTER_FEATURE_COLUMNS,
+    build_routed_ensemble_router_frame,
+    bundle_feature_columns,
+    make_routed_ensemble_bundle,
+    normalize_model_bundle,
+    predict_bundle_probabilities,
+)
+from aetherflow_strategy import augment_aetherflow_phase_features  # noqa: E402
+
+
+def _resolve_path(path_text: str, default_relative: str = "") -> Path:
+    raw = str(path_text or "").strip()
+    path = Path(raw).expanduser() if raw else (ROOT / default_relative)
+    if not path.is_absolute():
+        path = ROOT / path
+    return path.resolve()
+
+
+def _load_bundle(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        return normalize_model_bundle(pickle.load(fh))
+
+
+def _load_threshold_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _load_activation_rules(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    raw_rules = payload.get("rules", payload if isinstance(payload, list) else [])
+    if not isinstance(raw_rules, list):
+        return []
+    return [dict(item) for item in raw_rules if isinstance(item, dict)]
+
+
+def _allowed_setup_families(payload: dict[str, Any]) -> list[str]:
+    return [
+        str(item).strip()
+        for item in (payload.get("allowed_setup_families", []) or [])
+        if str(item).strip()
+    ]
+
+
+def _blocked_regimes(payload: dict[str, Any]) -> list[str]:
+    return [
+        str(item).strip().upper()
+        for item in (payload.get("hazard_block_regimes", []) or [])
+        if str(item).strip()
+    ]
+
+
+def _clip_probs(values: np.ndarray) -> np.ndarray:
+    return np.clip(np.asarray(values, dtype=float), 1e-6, 1.0 - 1e-6)
+
+
+def _logloss_per_row(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    y = np.asarray(y_true, dtype=float)
+    p = _clip_probs(prob)
+    return -(y * np.log(p) + (1.0 - y) * np.log(1.0 - p))
+
+
+def _logloss(y_true: np.ndarray, prob: np.ndarray) -> float:
+    return float(np.mean(_logloss_per_row(y_true, prob))) if len(y_true) else float("nan")
+
+
+def _brier(y_true: np.ndarray, prob: np.ndarray) -> float:
+    y = np.asarray(y_true, dtype=float)
+    p = np.asarray(prob, dtype=float)
+    return float(np.mean(np.square(p - y))) if len(y_true) else float("nan")
+
+
+def _auc(y_true: np.ndarray, prob: np.ndarray) -> float:
+    y = np.asarray(y_true, dtype=int)
+    if len(y) == 0 or np.unique(y).size < 2:
+        return float("nan")
+    return float(roc_auc_score(y, np.asarray(prob, dtype=float)))
+
+
+def _predict_in_batches(bundle: dict[str, Any], features: pd.DataFrame, batch_size: int) -> np.ndarray:
+    if features.empty:
+        return np.asarray([], dtype=float)
+    outputs: list[np.ndarray] = []
+    for start in range(0, len(features), max(1, int(batch_size))):
+        batch = features.iloc[start : start + int(batch_size)]
+        outputs.append(np.asarray(predict_bundle_probabilities(bundle, batch), dtype=float))
+    return np.concatenate(outputs, axis=0) if outputs else np.asarray([], dtype=float)
+
+
+def _frame_to_jsonable(frame: pd.DataFrame) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for _, row in frame.iterrows():
+        payload: dict[str, Any] = {}
+        for key, value in row.items():
+            if pd.isna(value):
+                payload[str(key)] = None
+            elif isinstance(value, (np.integer,)):
+                payload[str(key)] = int(value)
+            elif isinstance(value, (np.floating,)):
+                payload[str(key)] = float(value)
+            else:
+                payload[str(key)] = value
+        rows.append(payload)
+    return rows
+
+
+def _blend_with_adaptive_weight(stable_prob: np.ndarray, adaptive_prob: np.ndarray, adaptive_weight: np.ndarray) -> np.ndarray:
+    w = np.asarray(adaptive_weight, dtype=float)
+    stable = np.asarray(stable_prob, dtype=float)
+    adaptive = np.asarray(adaptive_prob, dtype=float)
+    return ((1.0 - w) * stable) + (w * adaptive)
+
+
+def _candidate_weight_grid() -> list[tuple[float, float]]:
+    floors = [0.05, 0.10, 0.15, 0.20]
+    ceilings = [0.80, 0.85, 0.90, 0.95]
+    out: list[tuple[float, float]] = []
+    for floor in floors:
+        for ceiling in ceilings:
+            if ceiling > floor:
+                out.append((float(floor), float(ceiling)))
+    return out
+
+
+def _split_mask(index: pd.DatetimeIndex, start: str | None, end: str | None) -> np.ndarray:
+    mask = np.ones(len(index), dtype=bool)
+    if start:
+        mask &= index >= pd.Timestamp(start, tz=index.tz)
+    if end:
+        mask &= index <= pd.Timestamp(end, tz=index.tz)
+    return mask
+
+
+def _metrics_payload(y_true: np.ndarray, prob: np.ndarray) -> dict[str, Any]:
+    return {
+        "rows": int(len(y_true)),
+        "positive_rate": float(np.mean(np.asarray(y_true, dtype=float))) if len(y_true) else float("nan"),
+        "logloss": _logloss(y_true, prob),
+        "brier": _brier(y_true, prob),
+        "auc": _auc(y_true, prob),
+        "prob_mean": float(np.mean(np.asarray(prob, dtype=float))) if len(y_true) else float("nan"),
+    }
+
+
+def _fit_router(
+    x_train: pd.DataFrame,
+    y_train: np.ndarray,
+    *,
+    sample_weight: np.ndarray,
+    max_depth: int,
+    max_iter: int,
+    learning_rate: float,
+    min_samples_leaf: int,
+    random_state: int,
+) -> HistGradientBoostingClassifier:
+    model = HistGradientBoostingClassifier(
+        loss="log_loss",
+        learning_rate=float(learning_rate),
+        max_iter=int(max_iter),
+        max_depth=int(max_depth),
+        min_samples_leaf=int(min_samples_leaf),
+        l2_regularization=0.05,
+        random_state=int(random_state),
+    )
+    model.fit(x_train, y_train, sample_weight=sample_weight)
+    return model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a routed two-expert AetherFlow ensemble artifact.")
+    parser.add_argument("--stable-model-file", required=True)
+    parser.add_argument("--stable-thresholds-file", required=True)
+    parser.add_argument("--adaptive-model-file", required=True)
+    parser.add_argument("--adaptive-thresholds-file", required=True)
+    parser.add_argument("--features-parquet", required=True)
+    parser.add_argument("--output-model-file", required=True)
+    parser.add_argument("--output-thresholds-file", required=True)
+    parser.add_argument("--output-metrics-file", required=True)
+    parser.add_argument("--activation-rules-file", default=None)
+    parser.add_argument("--train-end", default="2024-12-31 23:59")
+    parser.add_argument("--validation-end", default="2025-12-31 23:59")
+    parser.add_argument("--refit-through-validation", action="store_true")
+    parser.add_argument("--batch-size", type=int, default=50000)
+    parser.add_argument("--max-depth", type=int, default=4)
+    parser.add_argument("--max-iter", type=int, default=250)
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--min-samples-leaf", type=int, default=256)
+    parser.add_argument("--random-state", type=int, default=1337)
+    args = parser.parse_args()
+
+    stable_model_path = _resolve_path(str(args.stable_model_file))
+    stable_thresholds_path = _resolve_path(str(args.stable_thresholds_file))
+    adaptive_model_path = _resolve_path(str(args.adaptive_model_file))
+    adaptive_thresholds_path = _resolve_path(str(args.adaptive_thresholds_file))
+    features_path = _resolve_path(str(args.features_parquet))
+    output_model_path = _resolve_path(str(args.output_model_file))
+    output_thresholds_path = _resolve_path(str(args.output_thresholds_file))
+    output_metrics_path = _resolve_path(str(args.output_metrics_file))
+    activation_rules_path = _resolve_path(str(args.activation_rules_file)) if args.activation_rules_file else None
+
+    stable_bundle = _load_bundle(stable_model_path)
+    adaptive_bundle = _load_bundle(adaptive_model_path)
+    stable_thresholds = _load_threshold_payload(stable_thresholds_path)
+    adaptive_thresholds = _load_threshold_payload(adaptive_thresholds_path)
+    activation_rules = _load_activation_rules(activation_rules_path)
+
+    output_model_path.parent.mkdir(parents=True, exist_ok=True)
+    output_thresholds_path.parent.mkdir(parents=True, exist_ok=True)
+    output_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = pd.read_parquet(features_path)
+    data = ensure_feature_columns(data)
+    data = data.replace([np.inf, -np.inf], np.nan)
+    data = data.dropna(subset=["label", "net_points"]).copy()
+    data["label"] = pd.to_numeric(data["label"], errors="coerce").fillna(0).astype(int)
+    data = data.sort_index()
+    data = augment_aetherflow_phase_features(data)
+
+    live_families = _allowed_setup_families(stable_thresholds)
+    if live_families:
+        data = data.loc[data["setup_family"].astype(str).isin(live_families)].copy()
+    blocked_regimes = set(_blocked_regimes(stable_thresholds))
+    if blocked_regimes and "manifold_regime_name" in data.columns:
+        data = data.loc[~data["manifold_regime_name"].astype(str).str.upper().isin(sorted(blocked_regimes))].copy()
+    if data.empty:
+        raise RuntimeError("No routed-ensemble training rows remain after live-family filtering.")
+
+    stable_prob = _predict_in_batches(stable_bundle, data, int(args.batch_size))
+    adaptive_prob = _predict_in_batches(adaptive_bundle, data, int(args.batch_size))
+    labels = data["label"].to_numpy(dtype=int)
+
+    stable_loss = _logloss_per_row(labels, stable_prob)
+    adaptive_loss = _logloss_per_row(labels, adaptive_prob)
+    loss_gap = stable_loss - adaptive_loss
+    router_target = (loss_gap > 0.0).astype(int)
+    router_weight = np.maximum(np.abs(loss_gap), 0.01)
+
+    router_frame = build_routed_ensemble_router_frame(
+        data,
+        {
+            "stable": stable_prob,
+            "adaptive": adaptive_prob,
+        },
+    )
+    router_feature_columns = [
+        col for col in ROUTED_ENSEMBLE_DEFAULT_ROUTER_FEATURE_COLUMNS if col in router_frame.columns
+    ] or list(router_frame.columns)
+    router_frame = router_frame.reindex(columns=router_feature_columns, fill_value=0.0).replace([np.inf, -np.inf], np.nan).fillna(0.0)
+
+    index = pd.DatetimeIndex(data.index)
+    train_mask = _split_mask(index, None, str(args.train_end))
+    val_mask = _split_mask(index, str(pd.Timestamp(args.train_end) + pd.Timedelta(minutes=1)), str(args.validation_end))
+    post_val_mask = _split_mask(index, str(pd.Timestamp(args.validation_end) + pd.Timedelta(minutes=1)), None)
+    jan_2026_mask = _split_mask(index, "2026-01-01", "2026-01-26 23:59")
+    fresh_2026_mask = _split_mask(index, "2026-01-27", None)
+
+    if not bool(train_mask.any()):
+        raise RuntimeError("Router train split is empty.")
+    if not bool(val_mask.any()):
+        raise RuntimeError("Router validation split is empty.")
+
+    router_model = _fit_router(
+        router_frame.loc[train_mask],
+        router_target[train_mask],
+        sample_weight=router_weight[train_mask],
+        max_depth=int(args.max_depth),
+        max_iter=int(args.max_iter),
+        learning_rate=float(args.learning_rate),
+        min_samples_leaf=int(args.min_samples_leaf),
+        random_state=int(args.random_state),
+    )
+    router_prob_val = np.asarray(router_model.predict_proba(router_frame.loc[val_mask])[:, 1], dtype=float)
+
+    weight_rows: list[dict[str, Any]] = []
+    best_floor = 0.05
+    best_ceiling = 0.95
+    best_logloss = math.inf
+    for floor, ceiling in _candidate_weight_grid():
+        adaptive_weight = floor + ((ceiling - floor) * router_prob_val)
+        blended_val = _blend_with_adaptive_weight(
+            stable_prob[val_mask],
+            adaptive_prob[val_mask],
+            adaptive_weight,
+        )
+        score = _logloss(labels[val_mask], blended_val)
+        weight_rows.append(
+            {
+                "floor": float(floor),
+                "ceiling": float(ceiling),
+                "validation_logloss": float(score),
+                "validation_brier": _brier(labels[val_mask], blended_val),
+                "validation_auc": _auc(labels[val_mask], blended_val),
+                "validation_prob_mean": float(np.mean(blended_val)),
+            }
+        )
+        if score < best_logloss:
+            best_logloss = float(score)
+            best_floor = float(floor)
+            best_ceiling = float(ceiling)
+
+    final_router_model = router_model
+    final_train_end = str(args.train_end)
+    if bool(args.refit_through_validation):
+        refit_mask = train_mask | val_mask
+        final_router_model = _fit_router(
+            router_frame.loc[refit_mask],
+            router_target[refit_mask],
+            sample_weight=router_weight[refit_mask],
+            max_depth=int(args.max_depth),
+            max_iter=int(args.max_iter),
+            learning_rate=float(args.learning_rate),
+            min_samples_leaf=int(args.min_samples_leaf),
+            random_state=int(args.random_state),
+        )
+        final_train_end = str(args.validation_end)
+
+    bundle = make_routed_ensemble_bundle(
+        experts=[
+            {"name": "stable", "bundle": stable_bundle},
+            {"name": "adaptive", "bundle": adaptive_bundle},
+        ],
+        router_model=final_router_model,
+        router_feature_columns=router_feature_columns,
+        threshold=float(stable_thresholds.get("threshold", stable_bundle.get("threshold", 0.54)) or 0.54),
+        trained_at=pd.Timestamp.now("UTC").isoformat(),
+        walkforward_fold="routed_ensemble_2011_2025",
+        router_mode="soft_blend",
+        router_weight_floor=float(best_floor),
+        router_weight_ceiling=float(best_ceiling),
+        router_training_report={
+            "train_end": str(args.train_end),
+            "validation_end": str(args.validation_end),
+            "effective_router_fit_end": final_train_end,
+            "router_target": "adaptive_better_logloss",
+            "router_positive_rate_train": float(np.mean(router_target[train_mask])) if bool(train_mask.any()) else None,
+            "router_positive_rate_validation": float(np.mean(router_target[val_mask])) if bool(val_mask.any()) else None,
+            "weight_grid_results": weight_rows,
+            "selected_floor": float(best_floor),
+            "selected_ceiling": float(best_ceiling),
+            "stable_model_file": str(stable_model_path),
+            "adaptive_model_file": str(adaptive_model_path),
+        },
+        router_activation_rules=activation_rules,
+        router_fallback_expert="stable",
+    )
+    normalized_bundle = normalize_model_bundle(bundle)
+    full_router_prob = np.asarray(final_router_model.predict_proba(router_frame)[:, 1], dtype=float)
+    routed_prob = _predict_in_batches(normalized_bundle, data, int(args.batch_size))
+    adaptive_weight = np.zeros(len(data), dtype=float)
+    denom = np.asarray(adaptive_prob, dtype=float) - np.asarray(stable_prob, dtype=float)
+    valid = np.abs(denom) > 1e-9
+    adaptive_weight[valid] = (np.asarray(routed_prob, dtype=float)[valid] - np.asarray(stable_prob, dtype=float)[valid]) / denom[valid]
+    adaptive_weight = np.clip(adaptive_weight, 0.0, 1.0)
+
+    with output_model_path.open("wb") as fh:
+        pickle.dump(bundle, fh, protocol=pickle.HIGHEST_PROTOCOL)
+    thresholds_payload = {
+        "threshold": float(stable_thresholds.get("threshold", normalized_bundle.get("threshold", 0.54)) or 0.54),
+        "bundle_design": str(normalized_bundle.get("bundle_design", "routed_ensemble") or "routed_ensemble"),
+        "feature_columns": bundle_feature_columns(normalized_bundle),
+        "router_mode": "soft_blend",
+        "router_feature_columns": list(router_feature_columns),
+        "router_weight_floor": float(best_floor),
+        "router_weight_ceiling": float(best_ceiling),
+        "router_activation_rules": activation_rules,
+        "router_fallback_expert": "stable",
+        "allowed_setup_families": live_families,
+        "hazard_block_regimes": sorted(blocked_regimes),
+        "experts": [
+            {
+                "name": "stable",
+                "model_file": str(stable_model_path),
+                "thresholds_file": str(stable_thresholds_path),
+                "bundle_design": str(stable_bundle.get("bundle_design", "single") or "single"),
+                "conditional_models": len(stable_bundle.get("conditional_models", []) or []),
+            },
+            {
+                "name": "adaptive",
+                "model_file": str(adaptive_model_path),
+                "thresholds_file": str(adaptive_thresholds_path),
+                "bundle_design": str(adaptive_bundle.get("bundle_design", "single") or "single"),
+                "conditional_models": len(adaptive_bundle.get("conditional_models", []) or []),
+            },
+        ],
+        "source_thresholds_payload": {
+            "stable": stable_thresholds,
+            "adaptive": adaptive_thresholds,
+        },
+        "packaged_at": pd.Timestamp.now("UTC").isoformat(),
+    }
+    output_thresholds_path.write_text(json.dumps(thresholds_payload, indent=2), encoding="utf-8")
+
+    split_masks = {
+        "train_2011_2024": train_mask,
+        "validation_2025": val_mask,
+        "holdout_post_validation": post_val_mask,
+        "jan_2026": jan_2026_mask,
+        "fresh_2026_post_jan26": fresh_2026_mask,
+    }
+    split_metrics: dict[str, Any] = {}
+    for name, mask in split_masks.items():
+        if not bool(mask.any()):
+            continue
+        split_metrics[name] = {
+            "stable": _metrics_payload(labels[mask], stable_prob[mask]),
+            "adaptive": _metrics_payload(labels[mask], adaptive_prob[mask]),
+            "routed": _metrics_payload(labels[mask], routed_prob[mask]),
+            "adaptive_weight_mean": float(np.mean(adaptive_weight[mask])),
+            "adaptive_weight_median": float(np.median(adaptive_weight[mask])),
+        }
+
+    metrics_payload = {
+        "artifact": {
+            "model_file": str(output_model_path),
+            "thresholds_file": str(output_thresholds_path),
+            "features_parquet": str(features_path),
+        },
+        "training_rows": int(len(data)),
+        "training_families": live_families,
+        "blocked_regimes": sorted(blocked_regimes),
+        "router": {
+            "feature_columns": list(router_feature_columns),
+            "selected_floor": float(best_floor),
+            "selected_ceiling": float(best_ceiling),
+            "fit_end": final_train_end,
+            "activation_rules_file": str(activation_rules_path) if activation_rules_path is not None else None,
+            "activation_rules": activation_rules,
+            "params": {
+                "max_depth": int(args.max_depth),
+                "max_iter": int(args.max_iter),
+                "learning_rate": float(args.learning_rate),
+                "min_samples_leaf": int(args.min_samples_leaf),
+                "random_state": int(args.random_state),
+            },
+            "router_train_positive_rate": float(np.mean(router_target[train_mask])) if bool(train_mask.any()) else None,
+            "router_validation_positive_rate": float(np.mean(router_target[val_mask])) if bool(val_mask.any()) else None,
+            "weight_grid_results": weight_rows,
+        },
+        "split_metrics": split_metrics,
+        "score_distribution": {
+            "stable_mean": float(np.mean(stable_prob)),
+            "adaptive_mean": float(np.mean(adaptive_prob)),
+            "routed_mean": float(np.mean(routed_prob)),
+            "adaptive_weight_mean": float(np.mean(adaptive_weight)),
+            "adaptive_weight_q10": float(np.quantile(adaptive_weight, 0.10)),
+            "adaptive_weight_q50": float(np.quantile(adaptive_weight, 0.50)),
+            "adaptive_weight_q90": float(np.quantile(adaptive_weight, 0.90)),
+        },
+        "expert_gap_summary": {
+            "adaptive_better_share_all": float(np.mean(router_target)),
+            "adaptive_better_share_abs_gap_ge_005": float(np.mean(np.abs(loss_gap) >= 0.05)),
+            "stable_logloss_all": _logloss(labels, stable_prob),
+            "adaptive_logloss_all": _logloss(labels, adaptive_prob),
+            "routed_logloss_all": _logloss(labels, routed_prob),
+        },
+    }
+    output_metrics_path.write_text(json.dumps(metrics_payload, indent=2), encoding="utf-8")
+
+    preview = pd.DataFrame(weight_rows).sort_values(["validation_logloss", "validation_brier"], ascending=[True, True]).head(8)
+    print(f"output_model={output_model_path}")
+    print(f"output_thresholds={output_thresholds_path}")
+    print(f"output_metrics={output_metrics_path}")
+    print(f"selected_floor={best_floor:.3f}")
+    print(f"selected_ceiling={best_ceiling:.3f}")
+    print("top_weight_grid=" + json.dumps(_frame_to_jsonable(preview), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/calibrate_aetherflow_bundle.py
+++ b/tools/calibrate_aetherflow_bundle.py
@@ -1,0 +1,162 @@
+import argparse
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from aetherflow_features import ensure_feature_columns  # noqa: E402
+from aetherflow_model_bundle import normalize_model_bundle, predict_bundle_probabilities  # noqa: E402
+
+
+def _resolve_path(path_text: str, default_relative: str = "") -> Path:
+    raw = str(path_text or "").strip()
+    path = Path(raw).expanduser() if raw else (ROOT / default_relative)
+    if not path.is_absolute():
+        path = ROOT / path
+    return path.resolve()
+
+
+def _fit_logit_linear_calibrator(probabilities: np.ndarray, labels: np.ndarray, *, min_rows: int) -> dict | None:
+    probs = np.asarray(probabilities, dtype=float)
+    y = np.asarray(labels, dtype=np.int8)
+    valid_mask = np.isfinite(probs)
+    probs = probs[valid_mask]
+    y = y[valid_mask]
+    if probs.size < int(min_rows) or len(np.unique(y)) < 2:
+        return None
+    clipped = np.clip(probs, 1e-6, 1.0 - 1e-6)
+    logits = np.log(clipped / (1.0 - clipped)).reshape(-1, 1)
+    calibrator = LogisticRegression(
+        solver="lbfgs",
+        max_iter=250,
+        random_state=42,
+    )
+    calibrator.fit(logits, y)
+    return {
+        "kind": "logit_linear",
+        "coef": float(calibrator.coef_[0][0]),
+        "intercept": float(calibrator.intercept_[0]),
+        "rows": int(len(y)),
+        "positive_rate": float(np.mean(y.astype(float))),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fit a shared logit-linear calibrator onto an existing AetherFlow bundle.")
+    parser.add_argument("--model-file", required=True)
+    parser.add_argument("--thresholds-file", required=True)
+    parser.add_argument("--features-parquet", required=True)
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--mode", choices=["shared", "per_family"], default="shared")
+    parser.add_argument("--min-rows", type=int, default=800)
+    parser.add_argument("--family-min-rows", type=int, default=None)
+    parser.add_argument("--output-model-file", required=True)
+    parser.add_argument("--output-thresholds-file", required=True)
+    args = parser.parse_args()
+
+    model_path = _resolve_path(args.model_file)
+    thresholds_path = _resolve_path(args.thresholds_file)
+    features_path = _resolve_path(args.features_parquet)
+    output_model_path = _resolve_path(args.output_model_file)
+    output_thresholds_path = _resolve_path(args.output_thresholds_file)
+    output_model_path.parent.mkdir(parents=True, exist_ok=True)
+    output_thresholds_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with model_path.open("rb") as fh:
+        raw_bundle = pickle.load(fh)
+    bundle = normalize_model_bundle(raw_bundle)
+
+    df = pd.read_parquet(features_path)
+    df = ensure_feature_columns(df)
+    df.index = pd.to_datetime(df.index)
+    start_ts = pd.Timestamp(args.start)
+    end_ts = pd.Timestamp(args.end)
+    if getattr(df.index, "tz", None) is not None:
+        tz = df.index.tz
+        if start_ts.tzinfo is None:
+            start_ts = start_ts.tz_localize(tz)
+        else:
+            start_ts = start_ts.tz_convert(tz)
+        if end_ts.tzinfo is None:
+            end_ts = end_ts.tz_localize(tz)
+        else:
+            end_ts = end_ts.tz_convert(tz)
+    frame = df.loc[(df.index >= start_ts) & (df.index <= end_ts)].copy()
+    frame = frame.loc[pd.to_numeric(frame.get("candidate_side", 0.0), errors="coerce").fillna(0.0) != 0.0].copy()
+    frame = frame.replace([np.inf, -np.inf], np.nan).dropna(subset=["label"])
+    if frame.empty:
+        raise RuntimeError("No calibration rows found in requested window.")
+
+    probs = predict_bundle_probabilities(bundle, frame)
+    calibrator = _fit_logit_linear_calibrator(
+        probs,
+        frame["label"].astype(int).to_numpy(dtype=np.int8),
+        min_rows=int(args.min_rows),
+    )
+    if calibrator is None:
+        raise RuntimeError("Calibration fit failed or not enough rows.")
+    family_calibrators: dict[str, dict] = {}
+    if str(args.mode or "shared").strip().lower() == "per_family":
+        family_min_rows = int(args.family_min_rows if args.family_min_rows is not None else args.min_rows)
+        family_series = frame["setup_family"].astype(str)
+        for family_name in sorted(family_series.dropna().unique().tolist()):
+            family_mask = family_series.eq(str(family_name)).to_numpy(dtype=bool)
+            family_calibrator = _fit_logit_linear_calibrator(
+                probs[family_mask],
+                frame.loc[family_mask, "label"].astype(int).to_numpy(dtype=np.int8),
+                min_rows=family_min_rows,
+            )
+            if family_calibrator is not None:
+                family_calibrators[str(family_name)] = family_calibrator
+
+    if isinstance(raw_bundle, dict):
+        raw_bundle = dict(raw_bundle)
+        raw_bundle["shared_calibrator"] = dict(calibrator)
+        raw_bundle["family_calibrators"] = dict(family_calibrators)
+    else:
+        raise RuntimeError("Unsupported model bundle format; expected dict-like bundle.")
+
+    with output_model_path.open("wb") as fh:
+        pickle.dump(raw_bundle, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+    thresholds_payload = {}
+    if thresholds_path.exists():
+        try:
+            thresholds_payload = json.loads(thresholds_path.read_text(encoding="utf-8"))
+            if not isinstance(thresholds_payload, dict):
+                thresholds_payload = {}
+        except Exception:
+            thresholds_payload = {}
+    thresholds_payload["shared_calibrator"] = dict(calibrator)
+    thresholds_payload["family_calibrators"] = dict(family_calibrators)
+    thresholds_payload["calibration_window"] = {
+        "start": str(start_ts.date()),
+        "end": str(end_ts.date()),
+        "mode": str(args.mode),
+    }
+    output_thresholds_path.write_text(json.dumps(thresholds_payload, indent=2), encoding="utf-8")
+
+    print(f"output_model={output_model_path}")
+    print(f"output_thresholds={output_thresholds_path}")
+    print(
+        json.dumps(
+            {
+                "shared_calibrator": calibrator,
+                "family_calibrators": family_calibrators,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_de3_live_lineage_percent_workflow.py
+++ b/tools/run_de3_live_lineage_percent_workflow.py
@@ -1,0 +1,906 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shlex
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from de3_v4_schema import build_family_id, safe_float
+
+
+DEFAULT_WINDOWS = [
+    {"name": "oos_2025", "start": "2025-01-01", "end": "2025-12-31"},
+    {"name": "full_2024_2025", "start": "2024-01-01", "end": "2025-12-31"},
+    {"name": "full_2011_2025", "start": "2011-01-01", "end": "2025-12-31"},
+]
+
+
+def _resolve_path(raw: str) -> Path:
+    path = Path(str(raw or "").strip()).expanduser()
+    if path.is_absolute():
+        return path
+    return ROOT / path
+
+
+def _parse_csv_list(raw: str) -> List[str]:
+    return [item.strip() for item in str(raw or "").split(",") if item.strip()]
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True), encoding="utf-8")
+
+
+def _quote_ps(parts: List[str]) -> str:
+    return " ".join(shlex.quote(str(part)) for part in parts)
+
+
+def _require_existing_paths(*, reason: str, paths: List[Path]) -> None:
+    missing = [str(path) for path in paths if not path.exists()]
+    if missing:
+        raise SystemExit(f"{reason}: missing required path(s): {', '.join(missing)}")
+
+
+def _run_stage(
+    *,
+    name: str,
+    command: List[str],
+    artifact_root: Path,
+    manifest: Dict[str, Any],
+    dry_run: bool,
+    expected_paths: Optional[List[Path]] = None,
+) -> None:
+    logs_dir = artifact_root / "workflow_logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"{name}.log"
+    stage_meta = {
+        "name": name,
+        "command": command,
+        "cwd": str(ROOT),
+        "log_path": str(log_path),
+        "started_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": "dry_run" if dry_run else "running",
+    }
+    manifest.setdefault("stages", []).append(stage_meta)
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+
+    if dry_run:
+        print(f"[dry-run] {name}: {_quote_ps(command)}")
+        stage_meta["finished_at_utc"] = datetime.now(timezone.utc).isoformat()
+        return
+
+    print(f"[stage] {name}")
+    print(f"[cmd] {_quote_ps(command)}")
+    started = time.perf_counter()
+    with log_path.open("w", encoding="utf-8", newline="") as handle:
+        process = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            handle.write(line)
+            handle.flush()
+            print(line, end="")
+        return_code = int(process.wait())
+
+    stage_meta["elapsed_sec"] = float(time.perf_counter() - started)
+    stage_meta["return_code"] = return_code
+    stage_meta["finished_at_utc"] = datetime.now(timezone.utc).isoformat()
+    stage_meta["status"] = "ok" if return_code == 0 else "failed"
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+    if return_code != 0:
+        raise SystemExit(f"Stage failed: {name} (see {log_path})")
+
+    missing = [str(path) for path in (expected_paths or []) if not path.exists()]
+    if missing:
+        stage_meta["status"] = "failed"
+        stage_meta["missing_expected_paths"] = missing
+        _write_json(artifact_root / "workflow_manifest.json", manifest)
+        raise SystemExit(
+            f"Stage {name} finished without expected outputs: {', '.join(missing)}"
+        )
+
+
+def _run_inline_stage(
+    *,
+    name: str,
+    artifact_root: Path,
+    manifest: Dict[str, Any],
+    dry_run: bool,
+    expected_paths: Optional[List[Path]],
+    runner,
+) -> None:
+    logs_dir = artifact_root / "workflow_logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"{name}.log"
+    stage_meta = {
+        "name": name,
+        "command": ["<inline-python>"],
+        "cwd": str(ROOT),
+        "log_path": str(log_path),
+        "started_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": "dry_run" if dry_run else "running",
+    }
+    manifest.setdefault("stages", []).append(stage_meta)
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+
+    if dry_run:
+        print(f"[dry-run] {name}: inline stage")
+        stage_meta["finished_at_utc"] = datetime.now(timezone.utc).isoformat()
+        return
+
+    started = time.perf_counter()
+    with log_path.open("w", encoding="utf-8", newline="") as handle:
+        runner(handle)
+    stage_meta["elapsed_sec"] = float(time.perf_counter() - started)
+    stage_meta["return_code"] = 0
+    stage_meta["finished_at_utc"] = datetime.now(timezone.utc).isoformat()
+    stage_meta["status"] = "ok"
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+
+    missing = [str(path) for path in (expected_paths or []) if not path.exists()]
+    if missing:
+        stage_meta["status"] = "failed"
+        stage_meta["missing_expected_paths"] = missing
+        _write_json(artifact_root / "workflow_manifest.json", manifest)
+        raise SystemExit(
+            f"Stage {name} finished without expected outputs: {', '.join(missing)}"
+        )
+
+
+def _variant_rows_from_bundle(bundle: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for key in (
+        "long_rev_variants",
+        "short_rev_variants",
+        "long_mom_variants",
+        "short_mom_variants",
+    ):
+        payload = bundle.get(key, [])
+        if not isinstance(payload, list):
+            continue
+        for row in payload:
+            if isinstance(row, dict):
+                rows.append(dict(row))
+    if rows:
+        return rows
+    lane_variant_quality = (
+        bundle.get("lane_variant_quality", {})
+        if isinstance(bundle.get("lane_variant_quality"), dict)
+        else {}
+    )
+    for row in lane_variant_quality.values():
+        if isinstance(row, dict):
+            rows.append(dict(row))
+    return rows
+
+
+def _extract_control_family_targets(bundle: Dict[str, Any]) -> Dict[str, Any]:
+    variant_rows = _variant_rows_from_bundle(bundle)
+    family_counts: Counter[str] = Counter()
+    family_meta: Dict[str, Dict[str, Any]] = {}
+    for row in variant_rows:
+        family_id = str(row.get("family_id", "") or "").strip()
+        if not family_id:
+            continue
+        family_counts[family_id] += 1
+        family_meta.setdefault(
+            family_id,
+            {
+                "lane": str(row.get("lane", "") or ""),
+                "timeframe": str(row.get("timeframe", "") or ""),
+                "session": str(row.get("session", "") or ""),
+                "strategy_type": str(row.get("strategy_type", "") or ""),
+            },
+        )
+    family_bracket_selector = (
+        bundle.get("family_bracket_selector", {})
+        if isinstance(bundle.get("family_bracket_selector"), dict)
+        else {}
+    )
+    families_payload = (
+        family_bracket_selector.get("families", {})
+        if isinstance(family_bracket_selector.get("families"), dict)
+        else {}
+    )
+    for family_id in families_payload:
+        family_id_text = str(family_id or "").strip()
+        if family_id_text and family_id_text not in family_counts:
+            family_counts[family_id_text] = 1
+            family_meta.setdefault(family_id_text, {})
+    lane_inventory = (
+        bundle.get("lane_inventory", {})
+        if isinstance(bundle.get("lane_inventory"), dict)
+        else {}
+    )
+    return {
+        "family_counts": dict(family_counts),
+        "family_meta": family_meta,
+        "lane_inventory_counts": {
+            str(lane): len(values) if isinstance(values, list) else 0
+            for lane, values in lane_inventory.items()
+        },
+        "family_count": int(len(family_counts)),
+    }
+
+
+def _source_family_id(row: Dict[str, Any]) -> str:
+    return build_family_id(
+        timeframe=row.get("TF", row.get("timeframe", "")),
+        session=row.get("Session", row.get("session", "")),
+        strategy_type=row.get("Type", row.get("strategy_type", "")),
+        threshold=row.get("Thresh", row.get("thresh", 0.0)),
+        family_tag=row.get("FamilyTag", row.get("family_tag", "")),
+    )
+
+
+def _strategy_sort_key(row: Dict[str, Any]) -> tuple:
+    train = row.get("Train", {}) if isinstance(row.get("Train"), dict) else {}
+    recent = row.get("Recent", {}) if isinstance(row.get("Recent"), dict) else {}
+    oos = row.get("OOS", {}) if isinstance(row.get("OOS"), dict) else {}
+    return (
+        safe_float(row.get("Score"), -1e9),
+        safe_float(train.get("score_train"), -1e9),
+        safe_float(oos.get("profit_factor"), 0.0),
+        safe_float(recent.get("profit_factor"), 0.0),
+        safe_float(row.get("Trades"), 0.0),
+        safe_float(row.get("Avg_PnL"), -1e9),
+    )
+
+
+def _filter_percent_source_db(
+    *,
+    control_bundle_path: Path,
+    percent_source_db_path: Path,
+    filtered_db_path: Path,
+    audit_json_path: Path,
+    audit_csv_path: Path,
+) -> Dict[str, Any]:
+    control_bundle = json.loads(control_bundle_path.read_text(encoding="utf-8"))
+    control_targets = _extract_control_family_targets(control_bundle)
+    percent_payload = json.loads(percent_source_db_path.read_text(encoding="utf-8"))
+    strategies = percent_payload.get("strategies", [])
+    if not isinstance(strategies, list):
+        raise SystemExit(f"Invalid percent source DB payload: {percent_source_db_path}")
+
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in strategies:
+        if not isinstance(row, dict):
+            continue
+        family_id = _source_family_id(row)
+        if family_id:
+            grouped[family_id].append(dict(row))
+
+    selected_rows: List[Dict[str, Any]] = []
+    audit_rows: List[Dict[str, Any]] = []
+    missing_families: List[str] = []
+    extra_available_families = sorted(
+        family_id
+        for family_id in grouped.keys()
+        if family_id not in control_targets["family_counts"]
+    )
+    control_family_counts = control_targets["family_counts"]
+    control_family_meta = control_targets["family_meta"]
+    for family_id in sorted(control_family_counts.keys()):
+        target_count = max(1, int(control_family_counts.get(family_id, 1) or 1))
+        candidates = sorted(grouped.get(family_id, []), key=_strategy_sort_key, reverse=True)
+        selected = candidates[:target_count]
+        if not selected:
+            missing_families.append(family_id)
+        selected_rows.extend(selected)
+        meta = control_family_meta.get(family_id, {})
+        exemplar = selected[0] if selected else {}
+        audit_rows.append(
+            {
+                "family_id": family_id,
+                "lane": str(meta.get("lane", "")),
+                "timeframe": str(exemplar.get("TF", exemplar.get("timeframe", meta.get("timeframe", ""))) or ""),
+                "session": str(exemplar.get("Session", exemplar.get("session", meta.get("session", ""))) or ""),
+                "strategy_type": str(exemplar.get("Type", exemplar.get("strategy_type", meta.get("strategy_type", ""))) or ""),
+                "control_variant_count": int(target_count),
+                "percent_available_count": int(len(candidates)),
+                "selected_count": int(len(selected)),
+                "selected_strategy_ids": [
+                    str(row.get("strategy_id", row.get("id", "")) or "")
+                    for row in selected
+                ],
+                "missing": bool(not selected),
+            }
+        )
+
+    filtered_payload = dict(percent_payload)
+    filtered_payload["strategies"] = selected_rows
+    filtered_payload["lineage_filter_audit"] = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "control_bundle_path": str(control_bundle_path),
+        "percent_source_db_path": str(percent_source_db_path),
+        "control_family_count": int(len(control_family_counts)),
+        "selected_family_count": int(len({row["family_id"] for row in audit_rows if not row["missing"]})),
+        "selected_strategy_count": int(len(selected_rows)),
+        "missing_family_count": int(len(missing_families)),
+        "missing_families": missing_families,
+        "extra_available_family_count": int(len(extra_available_families)),
+        "extra_available_families_sample": extra_available_families[:50],
+        "control_lane_inventory_counts": control_targets["lane_inventory_counts"],
+    }
+    filtered_db_path.parent.mkdir(parents=True, exist_ok=True)
+    filtered_db_path.write_text(
+        json.dumps(filtered_payload, indent=2, ensure_ascii=True),
+        encoding="utf-8",
+    )
+
+    audit_payload = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "control_bundle_path": str(control_bundle_path),
+        "percent_source_db_path": str(percent_source_db_path),
+        "filtered_db_path": str(filtered_db_path),
+        "control_targets": control_targets,
+        "selected_strategy_count": int(len(selected_rows)),
+        "missing_families": missing_families,
+        "extra_available_families_sample": extra_available_families[:50],
+        "rows": audit_rows,
+    }
+    _write_json(audit_json_path, audit_payload)
+    audit_csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with audit_csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "family_id",
+                "lane",
+                "timeframe",
+                "session",
+                "strategy_type",
+                "control_variant_count",
+                "percent_available_count",
+                "selected_count",
+                "selected_strategy_ids",
+                "missing",
+            ],
+        )
+        writer.writeheader()
+        for row in audit_rows:
+            flat = dict(row)
+            flat["selected_strategy_ids"] = "|".join(row.get("selected_strategy_ids", []))
+            writer.writerow(flat)
+    return audit_payload
+
+
+def _load_candidate_bundles(candidate_summary_path: Path) -> List[Dict[str, str]]:
+    if not candidate_summary_path.exists():
+        return []
+    try:
+        summary = json.loads(candidate_summary_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    candidates = summary.get("candidates", {}) if isinstance(summary, dict) else {}
+    out: List[Dict[str, str]] = []
+    if not isinstance(candidates, dict):
+        return out
+    for name, row in candidates.items():
+        if not isinstance(row, dict):
+            continue
+        bundle_path = str(row.get("bundle_path", "") or "").strip()
+        if not bundle_path:
+            continue
+        out.append({"name": str(name), "bundle_path": bundle_path})
+    return out
+
+
+def _build_validation_command_specs(
+    *,
+    source_path: Path,
+    control_bundle_path: Path,
+    base_bundle_path: Path,
+    candidate_summary_path: Path,
+    artifact_root: Path,
+    symbol_mode: str,
+    symbol_method: str,
+) -> Dict[str, Any]:
+    bundles = [
+        {"name": "control_point_live", "bundle_path": str(control_bundle_path)},
+        {"name": "lineage_percent_base", "bundle_path": str(base_bundle_path)},
+    ]
+    bundles.extend(_load_candidate_bundles(candidate_summary_path))
+
+    commands: List[Dict[str, Any]] = []
+    ps_lines = [
+        "$ErrorActionPreference = 'Stop'",
+        f"Set-Location '{ROOT}'",
+        "",
+    ]
+    for bundle in bundles:
+        bundle_name = str(bundle["name"])
+        bundle_path = str(bundle["bundle_path"])
+        safe_name = bundle_name.replace(" ", "_")
+        for window in DEFAULT_WINDOWS:
+            report_dir = artifact_root / "backtest_reports" / "validation" / safe_name
+            cmd = [
+                sys.executable,
+                "-u",
+                "tools/run_de3_backtest.py",
+                "--source",
+                str(source_path),
+                "--start",
+                str(window["start"]),
+                "--end",
+                str(window["end"]),
+                "--symbol-mode",
+                symbol_mode,
+                "--symbol-method",
+                symbol_method,
+                "--bundle-path",
+                bundle_path,
+                "--sync-entry-model-from-bundle",
+                "--report-dir",
+                str(report_dir),
+            ]
+            commands.append(
+                {
+                    "bundle_name": bundle_name,
+                    "window_name": str(window["name"]),
+                    "start": str(window["start"]),
+                    "end": str(window["end"]),
+                    "command": cmd,
+                }
+            )
+            ps_lines.append(_quote_ps(cmd))
+        ps_lines.append("")
+
+    payload = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "source_path": str(source_path),
+        "commands": commands,
+    }
+    _write_json(artifact_root / "recommended_validation_commands.json", payload)
+    (artifact_root / "recommended_validation_commands.ps1").write_text(
+        "\n".join(ps_lines).strip() + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def _build_decision_audit_command_specs(
+    *,
+    source_path: Path,
+    control_bundle_path: Path,
+    base_bundle_path: Path,
+    candidate_summary_path: Path,
+    artifact_root: Path,
+    symbol_mode: str,
+    symbol_method: str,
+    decision_top_k: int,
+) -> Dict[str, Any]:
+    audit_root = artifact_root / "backtest_reports" / "decision_audit_2025"
+    bundles = [{"name": "lineage_percent_base", "bundle_path": str(base_bundle_path)}]
+    bundles.extend(_load_candidate_bundles(candidate_summary_path))
+
+    commands: List[Dict[str, Any]] = []
+    ps_lines = [
+        "$ErrorActionPreference = 'Stop'",
+        f"Set-Location '{ROOT}'",
+        "",
+    ]
+    control_decisions = audit_root / "control_point_live" / "de3_decisions_2025.csv"
+    control_cmd = [
+        sys.executable,
+        "-u",
+        "tools/run_de3_backtest.py",
+        "--source",
+        str(source_path),
+        "--start",
+        "2025-01-01",
+        "--end",
+        "2025-12-31",
+        "--symbol-mode",
+        symbol_mode,
+        "--symbol-method",
+        symbol_method,
+        "--bundle-path",
+        str(control_bundle_path),
+        "--sync-entry-model-from-bundle",
+        "--report-dir",
+        str(audit_root / "control_point_live"),
+        "--export-de3-decisions",
+        "--de3-decisions-top-k",
+        str(max(1, int(decision_top_k))),
+        "--de3-decisions-out",
+        str(control_decisions),
+    ]
+    commands.append({"name": "control_backtest_with_decisions", "command": control_cmd})
+    ps_lines.append(_quote_ps(control_cmd))
+    ps_lines.append("")
+
+    for bundle in bundles:
+        safe_name = str(bundle["name"]).replace(" ", "_")
+        candidate_decisions = audit_root / safe_name / "de3_decisions_2025.csv"
+        backtest_cmd = [
+            sys.executable,
+            "-u",
+            "tools/run_de3_backtest.py",
+            "--source",
+            str(source_path),
+            "--start",
+            "2025-01-01",
+            "--end",
+            "2025-12-31",
+            "--symbol-mode",
+            symbol_mode,
+            "--symbol-method",
+            symbol_method,
+            "--bundle-path",
+            str(bundle["bundle_path"]),
+            "--sync-entry-model-from-bundle",
+            "--report-dir",
+            str(audit_root / safe_name),
+            "--export-de3-decisions",
+            "--de3-decisions-top-k",
+            str(max(1, int(decision_top_k))),
+            "--de3-decisions-out",
+            str(candidate_decisions),
+        ]
+        compare_cmd = [
+            sys.executable,
+            "-u",
+            "tools/compare_de3_decision_exports.py",
+            "--control-decisions",
+            str(control_decisions),
+            "--candidate-decisions",
+            str(candidate_decisions),
+            "--out-dir",
+            str(audit_root / "compare" / safe_name),
+        ]
+        commands.append({"name": f"{safe_name}_backtest_with_decisions", "command": backtest_cmd})
+        commands.append({"name": f"{safe_name}_compare_vs_control", "command": compare_cmd})
+        ps_lines.append(_quote_ps(backtest_cmd))
+        ps_lines.append(_quote_ps(compare_cmd))
+        ps_lines.append("")
+
+    payload = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "source_path": str(source_path),
+        "commands": commands,
+    }
+    _write_json(artifact_root / "recommended_decision_audit_commands.json", payload)
+    (artifact_root / "recommended_decision_audit_commands.ps1").write_text(
+        "\n".join(ps_lines).strip() + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a percent-distance DE3 workflow that stays inside a point-mode live lineage. "
+            "The workflow filters a percent source DB down to the control bundle's family set, "
+            "rebuilds a v4 bundle from that filtered DB, retrains a scoped entry-policy set, "
+            "and writes control-vs-candidate validation/audit command packs."
+        )
+    )
+    parser.add_argument(
+        "--control-bundle",
+        default="artifacts/de3_v4_live/latest.json",
+        help="Point-mode live control bundle. Use the exact April 8 winner path here when known.",
+    )
+    parser.add_argument(
+        "--percent-source-db",
+        default="artifacts/de3_ground_up_20260419_pct_full_v1/dynamic_engine3_strategies_v2.outrights.json",
+        help="Percent-distance DE3 v2 DB used as the source pool for lineage filtering.",
+    )
+    parser.add_argument(
+        "--source",
+        default="es_master_outrights.parquet",
+        help="Primary outright-only source parquet.",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        default="",
+        help="Explicit output root. Defaults to artifacts/de3_live_lineage_percent_<timestamp>.",
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Optional suffix used when artifact root is auto-generated.",
+    )
+    parser.add_argument(
+        "--symbol-mode",
+        default="auto_by_day",
+        help="Symbol mode used for current-pool export and validations.",
+    )
+    parser.add_argument(
+        "--symbol-method",
+        default="volume",
+        help="Symbol method used for current-pool export and validations.",
+    )
+    parser.add_argument(
+        "--current-pool-start",
+        default="2011-01-01",
+        help="Start date for current-pool export.",
+    )
+    parser.add_argument(
+        "--current-pool-end",
+        default="2024-12-31",
+        help="End date for current-pool export.",
+    )
+    parser.add_argument(
+        "--entry-profile-set",
+        choices=("all", "current_pool", "shape", "rolling", "decision_direct"),
+        default="current_pool",
+        help="Named profile subset for entry/decision retraining.",
+    )
+    parser.add_argument(
+        "--candidate-profiles",
+        default="",
+        help="Optional comma-separated candidate names to train.",
+    )
+    parser.add_argument(
+        "--decision-audit-top-k",
+        type=int,
+        default=5,
+        help="Top-K decision journal depth for the generated audit command pack.",
+    )
+    parser.add_argument("--skip-filter-db", action="store_true", help="Assume the filtered percent DB already exists.")
+    parser.add_argument("--skip-v4", action="store_true", help="Assume the lineage percent bundle already exists.")
+    parser.add_argument("--skip-current-pool", action="store_true", help="Assume current-pool exports already exist.")
+    parser.add_argument("--skip-entry-policy", action="store_true", help="Skip entry-policy candidate retraining.")
+    parser.add_argument("--dry-run", action="store_true", help="Write manifests and commands without executing stages.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    control_bundle_path = _resolve_path(str(args.control_bundle))
+    percent_source_db_path = _resolve_path(str(args.percent_source_db))
+    source_path = _resolve_path(str(args.source))
+    _require_existing_paths(
+        reason="workflow setup",
+        paths=[control_bundle_path, percent_source_db_path, source_path],
+    )
+
+    if str(args.artifact_root or "").strip():
+        artifact_root = _resolve_path(str(args.artifact_root))
+    else:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        suffix = f"_{str(args.tag).strip()}" if str(args.tag).strip() else ""
+        artifact_root = ROOT / "artifacts" / f"de3_live_lineage_percent_{ts}{suffix}"
+    artifact_root.mkdir(parents=True, exist_ok=True)
+
+    filtered_db_path = artifact_root / "dynamic_engine3_strategies_v2.lineage_percent.json"
+    lineage_audit_json = artifact_root / "lineage_family_audit.json"
+    lineage_audit_csv = artifact_root / "lineage_family_audit.csv"
+    v4_bundle_path = artifact_root / "dynamic_engine3_v4_bundle.lineage_percent.json"
+    v4_reports_dir = artifact_root / "reports" / "lineage_bundle"
+    current_pool_decisions_path = artifact_root / "reports" / "de3_current_pool_2011_2024.csv"
+    current_pool_trade_path = artifact_root / "reports" / "de3_current_pool_2011_2024_trade_attribution.csv"
+    entry_policy_dir = artifact_root / "entry_policy_candidates"
+    candidate_summary_path = entry_policy_dir / "candidate_summary.json"
+
+    manifest: Dict[str, Any] = {
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "artifact_root": str(artifact_root),
+        "settings": {
+            "control_bundle": str(control_bundle_path),
+            "percent_source_db": str(percent_source_db_path),
+            "source_path": str(source_path),
+            "symbol_mode": str(args.symbol_mode),
+            "symbol_method": str(args.symbol_method),
+            "current_pool_start": str(args.current_pool_start),
+            "current_pool_end": str(args.current_pool_end),
+            "entry_profile_set": str(args.entry_profile_set),
+            "candidate_profiles": _parse_csv_list(str(args.candidate_profiles)),
+            "decision_audit_top_k": int(args.decision_audit_top_k),
+            "skip_filter_db": bool(args.skip_filter_db),
+            "skip_v4": bool(args.skip_v4),
+            "skip_current_pool": bool(args.skip_current_pool),
+            "skip_entry_policy": bool(args.skip_entry_policy),
+            "dry_run": bool(args.dry_run),
+        },
+        "artifacts": {
+            "filtered_db_path": str(filtered_db_path),
+            "lineage_audit_json": str(lineage_audit_json),
+            "lineage_audit_csv": str(lineage_audit_csv),
+            "v4_bundle_path": str(v4_bundle_path),
+            "v4_reports_dir": str(v4_reports_dir),
+            "current_pool_decisions_path": str(current_pool_decisions_path),
+            "current_pool_trade_attribution_path": str(current_pool_trade_path),
+            "entry_policy_dir": str(entry_policy_dir),
+            "candidate_summary_path": str(candidate_summary_path),
+        },
+        "stages": [],
+    }
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+
+    if bool(args.skip_filter_db) and not bool(args.dry_run):
+        _require_existing_paths(
+            reason="--skip-filter-db was set",
+            paths=[filtered_db_path, lineage_audit_json, lineage_audit_csv],
+        )
+    if not bool(args.skip_filter_db):
+        def _filter_runner(handle) -> None:
+            audit = _filter_percent_source_db(
+                control_bundle_path=control_bundle_path,
+                percent_source_db_path=percent_source_db_path,
+                filtered_db_path=filtered_db_path,
+                audit_json_path=lineage_audit_json,
+                audit_csv_path=lineage_audit_csv,
+            )
+            handle.write(json.dumps(audit, indent=2, ensure_ascii=True))
+            handle.write("\n")
+
+        _run_inline_stage(
+            name="filter_percent_source_db_to_live_lineage",
+            artifact_root=artifact_root,
+            manifest=manifest,
+            dry_run=bool(args.dry_run),
+            expected_paths=[filtered_db_path, lineage_audit_json, lineage_audit_csv],
+            runner=_filter_runner,
+        )
+
+    if bool(args.skip_v4) and not bool(args.dry_run):
+        _require_existing_paths(reason="--skip-v4 was set", paths=[v4_bundle_path])
+    if not bool(args.skip_v4):
+        _run_stage(
+            name="de3_v4_build",
+            command=[
+                sys.executable,
+                "-u",
+                "de3_v4_trainer.py",
+                "--source-db",
+                str(filtered_db_path),
+                "--source-parquet",
+                str(source_path),
+                "--out-bundle",
+                str(v4_bundle_path),
+                "--reports-dir",
+                str(v4_reports_dir),
+                "--full-build",
+                "--train-start",
+                "2011-01-01",
+                "--train-end",
+                "2023-12-31",
+                "--tune-start",
+                "2024-01-01",
+                "--tune-end",
+                "2024-12-31",
+                "--oos-start",
+                "2025-01-01",
+                "--oos-end",
+                "2025-12-31",
+                "--future-start",
+                "2026-01-01",
+            ],
+            artifact_root=artifact_root,
+            manifest=manifest,
+            dry_run=bool(args.dry_run),
+            expected_paths=[v4_bundle_path],
+        )
+
+    if bool(args.skip_current_pool) and not bool(args.dry_run):
+        _require_existing_paths(
+            reason="--skip-current-pool was set",
+            paths=[current_pool_decisions_path, current_pool_trade_path],
+        )
+    if not bool(args.skip_current_pool):
+        _run_stage(
+            name="de3_current_pool_export",
+            command=[
+                sys.executable,
+                "-u",
+                "tools/export_de3_current_pool.py",
+                "--source",
+                str(source_path),
+                "--start",
+                str(args.current_pool_start),
+                "--end",
+                str(args.current_pool_end),
+                "--symbol-mode",
+                str(args.symbol_mode),
+                "--symbol-method",
+                str(args.symbol_method),
+                "--bundle-path",
+                str(v4_bundle_path),
+                "--sync-entry-model-from-bundle",
+                "--report-dir",
+                str(artifact_root / "backtest_reports" / "current_pool"),
+                "--decisions-out",
+                str(current_pool_decisions_path),
+            ],
+            artifact_root=artifact_root,
+            manifest=manifest,
+            dry_run=bool(args.dry_run),
+            expected_paths=[current_pool_decisions_path, current_pool_trade_path],
+        )
+
+    if bool(args.skip_entry_policy) and not bool(args.dry_run):
+        _require_existing_paths(
+            reason="--skip-entry-policy was set",
+            paths=[candidate_summary_path],
+        )
+    if not bool(args.skip_entry_policy):
+        entry_cmd = [
+            sys.executable,
+            "-u",
+            "tools/train_de3_entry_policy_from_current_pool.py",
+            "--base-bundle",
+            str(v4_bundle_path),
+            "--decisions-csv",
+            str(current_pool_decisions_path),
+            "--trade-attribution-csv",
+            str(current_pool_trade_path),
+            "--output-dir",
+            str(entry_policy_dir),
+            "--profile-set",
+            str(args.entry_profile_set),
+        ]
+        candidate_profiles = _parse_csv_list(str(args.candidate_profiles))
+        if candidate_profiles:
+            entry_cmd.extend(["--only", ",".join(candidate_profiles)])
+        _run_stage(
+            name="de3_entry_policy_candidates",
+            command=entry_cmd,
+            artifact_root=artifact_root,
+            manifest=manifest,
+            dry_run=bool(args.dry_run),
+            expected_paths=[candidate_summary_path],
+        )
+
+    if not bool(args.dry_run):
+        _require_existing_paths(
+            reason="workflow requires the lineage percent bundle before command packs can be written",
+            paths=[v4_bundle_path],
+        )
+
+    validation_payload = _build_validation_command_specs(
+        source_path=source_path,
+        control_bundle_path=control_bundle_path,
+        base_bundle_path=v4_bundle_path,
+        candidate_summary_path=candidate_summary_path,
+        artifact_root=artifact_root,
+        symbol_mode=str(args.symbol_mode),
+        symbol_method=str(args.symbol_method),
+    )
+    decision_audit_payload = _build_decision_audit_command_specs(
+        source_path=source_path,
+        control_bundle_path=control_bundle_path,
+        base_bundle_path=v4_bundle_path,
+        candidate_summary_path=candidate_summary_path,
+        artifact_root=artifact_root,
+        symbol_mode=str(args.symbol_mode),
+        symbol_method=str(args.symbol_method),
+        decision_top_k=max(1, int(args.decision_audit_top_k or 1)),
+    )
+    manifest["validation_commands_path"] = str(artifact_root / "recommended_validation_commands.json")
+    manifest["validation_powershell_path"] = str(artifact_root / "recommended_validation_commands.ps1")
+    manifest["validation_command_count"] = int(len(validation_payload.get("commands", [])))
+    manifest["decision_audit_commands_path"] = str(artifact_root / "recommended_decision_audit_commands.json")
+    manifest["decision_audit_powershell_path"] = str(artifact_root / "recommended_decision_audit_commands.ps1")
+    manifest["decision_audit_command_count"] = int(len(decision_audit_payload.get("commands", [])))
+    _write_json(artifact_root / "workflow_manifest.json", manifest)
+
+    print(f"artifact_root={artifact_root}")
+    print(f"workflow_manifest={artifact_root / 'workflow_manifest.json'}")
+    print(f"validation_commands={artifact_root / 'recommended_validation_commands.json'}")
+    print(f"decision_audit_commands={artifact_root / 'recommended_decision_audit_commands.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_main_strategies_experimental_backtest.py
+++ b/tools/run_main_strategies_experimental_backtest.py
@@ -1,0 +1,195 @@
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import backtest_mes_et as bt
+from config import CONFIG
+from tools.run_filterless_flip_policy_compare import _prepare_symbol_df, _resolve_source
+from tools.run_live_strategy_day_compare import _extract_run_summary, _group_backtest_trades
+
+
+DEFAULT_STRATEGIES = [
+    "DynamicEngine3Strategy",
+    "RegimeAdaptiveStrategy",
+]
+
+STRATEGY_ALIASES = {
+    "de3": "DynamicEngine3Strategy",
+    "dynamicengine3": "DynamicEngine3Strategy",
+    "dynamicengine3strategy": "DynamicEngine3Strategy",
+    "regimeadaptive": "RegimeAdaptiveStrategy",
+    "regimeadaptivestrategy": "RegimeAdaptiveStrategy",
+    "aetherflow": "AetherFlowStrategy",
+    "aetherflowstrategy": "AetherFlowStrategy",
+}
+
+
+def _normalize_selected_strategies(values: list[str]) -> list[str]:
+    if not values:
+        return list(DEFAULT_STRATEGIES)
+    resolved: list[str] = []
+    for raw_value in values:
+        key = str(raw_value or "").strip()
+        if not key:
+            continue
+        strategy_name = STRATEGY_ALIASES.get(key.casefold(), key)
+        resolved.append(strategy_name)
+    unique = sorted(set(resolved))
+    if not unique:
+        raise SystemExit("No valid strategies selected.")
+    return unique
+
+
+def _run_backtest(
+    *,
+    symbol_df: pd.DataFrame,
+    start_time,
+    end_time,
+    selected_strategies: list[str],
+    workers: int,
+    experimental_enabled: bool,
+    live_report_dir: Path | None,
+) -> dict:
+    cfg_backup = copy.deepcopy(CONFIG)
+    try:
+        CONFIG.setdefault("GEMINI", {})["enabled"] = False
+        CONFIG["BACKTEST_CONSOLE_PROGRESS"] = False
+        CONFIG["BACKTEST_CONSOLE_STATUS"] = False
+        CONFIG["BACKTEST_WORKERS"] = max(1, int(workers))
+        CONFIG.setdefault("AETHERFLOW_STRATEGY", {})["enabled_backtest"] = True
+
+        experimental_cfg = copy.deepcopy(
+            CONFIG.get("BACKTEST_EXPERIMENTAL_MODIFIERS", {}) or {}
+        )
+        experimental_cfg["enabled"] = bool(experimental_enabled)
+        CONFIG["BACKTEST_EXPERIMENTAL_MODIFIERS"] = experimental_cfg
+
+        live_report_cfg = copy.deepcopy(CONFIG.get("BACKTEST_LIVE_REPORT", {}) or {})
+        live_report_cfg["enabled"] = True
+        live_report_cfg["include_trade_log"] = False
+        if live_report_dir is not None:
+            live_report_cfg["output_dir"] = str(live_report_dir)
+        CONFIG["BACKTEST_LIVE_REPORT"] = live_report_cfg
+
+        return bt.run_backtest(
+            symbol_df.copy(),
+            start_time,
+            end_time,
+            enabled_strategies=set(selected_strategies),
+            enabled_filters=set(),
+        )
+    finally:
+        CONFIG.clear()
+        CONFIG.update(cfg_backup)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a full-range backtest for the main filterless strategies, "
+            "optionally enabling structural-level and level-fill modifiers."
+        )
+    )
+    parser.add_argument("--source", default="es_master_outrights.parquet")
+    parser.add_argument("--start", default="2011-01-02")
+    parser.add_argument("--end", default="2026-04-17")
+    parser.add_argument("--symbol-mode", default="auto_by_day")
+    parser.add_argument("--symbol-method", default="volume")
+    parser.add_argument("--pre-roll-days", type=int, default=180)
+    parser.add_argument(
+        "--strategy",
+        action="append",
+        default=[],
+        help="Repeatable strategy selection: de3, regimeadaptive, aetherflow.",
+    )
+    parser.add_argument("--workers", type=int, default=12)
+    parser.add_argument(
+        "--experimental-enabled",
+        choices=["true", "false"],
+        default="true",
+        help="Enable or disable experimental structural-level and level-fill modifiers.",
+    )
+    parser.add_argument(
+        "--report-out",
+        default="reports/fullrange_main_strategies_experimental.json",
+    )
+    parser.add_argument(
+        "--live-report-dir",
+        default="backtest_reports/fullrange_main_strategies_experimental_live",
+    )
+    args = parser.parse_args()
+
+    selected_strategies = _normalize_selected_strategies(list(args.strategy or []))
+    source_path = _resolve_source(str(args.source))
+    start_time = bt.parse_user_datetime(str(args.start), bt.NY_TZ, is_end=False)
+    end_time = bt.parse_user_datetime(str(args.end), bt.NY_TZ, is_end=True)
+
+    symbol_df, symbol, symbol_distribution = _prepare_symbol_df(
+        source_path,
+        start_time,
+        end_time,
+        str(args.symbol_mode),
+        str(args.symbol_method),
+        pre_roll_days=max(0, int(args.pre_roll_days or 0)),
+    )
+
+    live_report_dir = Path(str(args.live_report_dir)).expanduser()
+    if not live_report_dir.is_absolute():
+        live_report_dir = (ROOT / live_report_dir).resolve()
+    live_report_dir.mkdir(parents=True, exist_ok=True)
+
+    stats = _run_backtest(
+        symbol_df=symbol_df,
+        start_time=start_time,
+        end_time=end_time,
+        selected_strategies=selected_strategies,
+        workers=int(args.workers),
+        experimental_enabled=str(args.experimental_enabled).strip().lower() == "true",
+        live_report_dir=live_report_dir,
+    )
+
+    grouped = _group_backtest_trades(list(stats.get("trade_log", []) or []))
+    payload = {
+        "created_at": pd.Timestamp.now(tz="America/New_York").isoformat(),
+        "source_path": str(source_path),
+        "window": {
+            "start": start_time.isoformat(),
+            "end": end_time.isoformat(),
+        },
+        "selected_strategies": list(selected_strategies),
+        "symbol": str(symbol),
+        "symbol_distribution": symbol_distribution,
+        "backtest_workers": int(args.workers),
+        "experimental_enabled": str(args.experimental_enabled).strip().lower() == "true",
+        "experimental": {
+            "summary": _extract_run_summary(stats),
+            "experimental_modifiers": dict(stats.get("experimental_modifiers", {}) or {}),
+            "by_strategy": {
+                name: dict((grouped.get(name) or {}).get("summary", {}) or {})
+                for name in selected_strategies
+            },
+        },
+        "live_report_dir": str(live_report_dir),
+    }
+
+    report_out = Path(str(args.report_out)).expanduser()
+    if not report_out.is_absolute():
+        report_out = (ROOT / report_out).resolve()
+    report_out.parent.mkdir(parents=True, exist_ok=True)
+    report_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    print(f"report={report_out}")
+    print(f"live_report_dir={live_report_dir}")
+    print(json.dumps(payload["experimental"]["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a full-range main-strategy experimental backtest runner.
- Add a DE3 live-lineage percent workflow driver for candidate generation, validation, and reporting.
- Add AetherFlow routed ensemble, multi-expert router, and calibration builders for local model/backtest research.

## Verification
- `python -m py_compile tools/run_main_strategies_experimental_backtest.py tools/run_de3_live_lineage_percent_workflow.py tools/build_aetherflow_multi_expert_router.py tools/build_aetherflow_routed_ensemble.py tools/calibrate_aetherflow_bundle.py`
- `graphify update .`

## Notes
- Source-only upload: generated reports, model files, parquet caches, scratch configs, and local readiness tests tied to uncommitted artifacts were intentionally excluded.