### PR TITLE
[codex] Make command center runtime controls useful

### DIFF
--- a/launch_filterless_workspace.py
+++ b/launch_filterless_workspace.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import atexit
 import argparse
 import ctypes
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
+import queue
 import shutil
 import socket
 import subprocess
@@ -38,6 +40,8 @@ WORKSPACE_STATUS_LOG_PATH = ROOT / "logs" / "filterless_workspace_launcher.statu
 WORKSPACE_PID_PATH = ROOT / "logs" / "filterless_workspace_pids.json"
 WORKSPACE_LOCK_PATH = ROOT / "logs" / "filterless_workspace.lock"
 VITE_PORT = 3000
+OPERATOR_CONTROL_HOST = "127.0.0.1"
+OPERATOR_CONTROL_PORT = 3011
 FILTERLESS_URL = f"http://localhost:{VITE_PORT}/filterless-live.html"
 DASHBOARD_STATE_PATH = MONTE_CARLO_DIR / "public" / "filterless_live_state.json"
 BOT_STALE_TIMEOUT_SECONDS = 180.0
@@ -643,6 +647,149 @@ def restart_managed_process(entry: dict[str, object]) -> None:
     entry["restart_count"] = int(entry.get("restart_count") or 0) + 1
 
 
+def operator_process_snapshot(entry: dict[str, object]) -> dict[str, object]:
+    name = str(entry.get("name") or "process")
+    process = entry.get("process")
+    exit_code: int | None = None
+    running = False
+    pid: int | None = None
+    if isinstance(process, subprocess.Popen):
+        exit_code = process.poll()
+        running = exit_code is None
+        pid = process.pid
+    watch_path = entry.get("watch_path")
+    watch_age = file_age_seconds(watch_path) if isinstance(watch_path, Path) else None
+    return {
+        "name": name,
+        "pid": pid,
+        "running": running,
+        "exit_code": exit_code,
+        "restart_count": int(entry.get("restart_count") or 0),
+        "watch_path": str(watch_path) if isinstance(watch_path, Path) else None,
+        "watch_age_seconds": round(watch_age, 1) if watch_age is not None else None,
+    }
+
+
+def operator_status_payload(managed: list[dict[str, object]], managed_lock: threading.Lock) -> dict[str, object]:
+    with managed_lock:
+        processes = [operator_process_snapshot(entry) for entry in managed]
+    dashboard_age = file_age_seconds(DASHBOARD_STATE_PATH)
+    return {
+        "ok": True,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "control_host": OPERATOR_CONTROL_HOST,
+        "control_port": OPERATOR_CONTROL_PORT,
+        "dashboard_state_path": str(DASHBOARD_STATE_PATH),
+        "dashboard_state_age_seconds": round(dashboard_age, 1) if dashboard_age is not None else None,
+        "processes": processes,
+    }
+
+
+def find_managed_entry(managed: list[dict[str, object]], target_name: str) -> dict[str, object] | None:
+    target = target_name.lower()
+    for entry in managed:
+        name = str(entry.get("name") or "").lower()
+        if name == target or target in name:
+            return entry
+    return None
+
+
+def process_operator_actions(
+    action_queue: "queue.Queue[str]",
+    managed: list[dict[str, object]],
+    managed_lock: threading.Lock,
+) -> bool:
+    action_targets = {
+        "restart_bot": "filterless bot",
+        "restart_bridge": "filterless dashboard bridge",
+        "restart_frontend": "filterless live ui",
+    }
+    handled = False
+    while True:
+        try:
+            action = action_queue.get_nowait()
+        except queue.Empty:
+            return handled
+        target = action_targets.get(action)
+        if not target:
+            log_workspace_status(f"Ignoring unknown operator action: {action}")
+            continue
+        with managed_lock:
+            entry = find_managed_entry(managed, target)
+            if entry is None:
+                log_workspace_status(f"Operator action {action} failed: target {target!r} not managed")
+                continue
+            log_workspace_status(f"Operator action requested: {action}")
+            restart_managed_process(entry)
+            record_managed_processes(managed)
+        handled = True
+
+
+def start_operator_control_server(
+    managed: list[dict[str, object]],
+    managed_lock: threading.Lock,
+    action_queue: "queue.Queue[str]",
+) -> ThreadingHTTPServer | None:
+    class OperatorControlHandler(BaseHTTPRequestHandler):
+        server_version = "JulieOperatorControl/1.0"
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+        def _send_json(self, status: int, payload: dict[str, object]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_OPTIONS(self) -> None:  # noqa: N802
+            self._send_json(200, {"ok": True})
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            if path != "/status":
+                self._send_json(404, {"ok": False, "error": "not found"})
+                return
+            self._send_json(200, operator_status_payload(managed, managed_lock))
+
+        def do_POST(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            if path != "/command":
+                self._send_json(404, {"ok": False, "error": "not found"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0") or "0")
+            except ValueError:
+                length = 0
+            try:
+                raw = self.rfile.read(max(0, min(length, 4096)))
+                payload = json.loads(raw.decode("utf-8") or "{}")
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                self._send_json(400, {"ok": False, "error": "invalid json"})
+                return
+            action = str(payload.get("action") or "").strip()
+            if action not in {"restart_bot", "restart_bridge", "restart_frontend"}:
+                self._send_json(400, {"ok": False, "error": "unknown action"})
+                return
+            action_queue.put(action)
+            self._send_json(202, {"ok": True, "queued": action})
+
+    try:
+        server = ThreadingHTTPServer((OPERATOR_CONTROL_HOST, OPERATOR_CONTROL_PORT), OperatorControlHandler)
+    except OSError as exc:
+        log_workspace_status(f"Operator control server disabled: {exc}")
+        return None
+    thread = threading.Thread(target=server.serve_forever, name="operator-control-server", daemon=True)
+    thread.start()
+    log_workspace_status(f"Operator control server listening on http://{OPERATOR_CONTROL_HOST}:{OPERATOR_CONTROL_PORT}")
+    return server
+
+
 def choose_account_id(account_id_override: Optional[str]) -> Optional[str]:
     if account_id_override:
         selected = str(account_id_override).strip() or None
@@ -731,6 +878,9 @@ def main() -> int:
         return 1
 
     managed: list[dict[str, object]] = []
+    managed_lock = threading.Lock()
+    operator_actions: queue.Queue[str] = queue.Queue()
+    operator_server: ThreadingHTTPServer | None = None
 
     try:
         log_workspace_status("Starting filterless bot process")
@@ -812,11 +962,14 @@ def main() -> int:
         )
         record_managed_processes(managed)
         log_workspace_status("All workspace processes launched")
+        operator_server = start_operator_control_server(managed, managed_lock, operator_actions)
 
         if not args.no_browser:
             open_browser_tabs(args.browser_delay)
 
         while True:
+            if process_operator_actions(operator_actions, managed, managed_lock):
+                continue
             restarted = False
             for entry in managed:
                 name = str(entry.get("name") or "process")
@@ -870,6 +1023,12 @@ def main() -> int:
         print("\nShutdown requested.")
         return 0
     finally:
+        if operator_server is not None:
+            try:
+                operator_server.shutdown()
+                operator_server.server_close()
+            except Exception:
+                pass
         for entry in reversed(managed):
             process = entry.get("process")
             if isinstance(process, subprocess.Popen):

--- a/montecarlo/Backtest-Simulator-main/FilterlessLiveCockpit.tsx
+++ b/montecarlo/Backtest-Simulator-main/FilterlessLiveCockpit.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useEffect, useMemo, useRef, useState } from 'react';
+import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   FilterlessEvent,
   FilterlessKalshiMetrics,
@@ -13,6 +13,7 @@ const REFRESH_MS = 3000;
 const FEED_STALE_SECONDS = 90;
 const FEED_OFFLINE_SECONDS = 300;
 const MANIFOLD_IDLE_FPS = 24;
+const OPERATOR_CONTROL_URL = 'http://127.0.0.1:3011';
 const TAU = Math.PI * 2;
 
 const COLORS = {
@@ -33,6 +34,24 @@ type ScreenId = 'overview' | 'aetherflow' | 'kalshi' | 'news' | 'strategies' | '
 
 type ManifoldRegime = 'TREND_GEODESIC' | 'CHOP_SPIRAL' | 'DISPERSED' | 'ROTATIONAL_TURBULENCE';
 type BadgeTone = 'live' | 'watch' | 'block' | 'info';
+type OperatorCommandAction = 'restart_bot' | 'restart_bridge' | 'restart_frontend';
+
+interface OperatorProcessStatus {
+  name: string;
+  pid?: number | null;
+  running: boolean;
+  exit_code?: number | null;
+  restart_count?: number | null;
+  watch_age_seconds?: number | null;
+}
+
+interface OperatorControlStatus {
+  ok: boolean;
+  generated_at: string;
+  dashboard_state_age_seconds?: number | null;
+  dashboard_state_path?: string | null;
+  processes: OperatorProcessStatus[];
+}
 
 interface AetherFeatures {
   pressure10: number;
@@ -272,6 +291,10 @@ h1, h2, h3, p { margin: 0; }
 .command-tile small { min-width: 0; color: var(--muted); font-family: var(--mono); font-size: 10px; }
 .control-tile { cursor: pointer; color: inherit; text-align: left; }
 .control-tile:hover { border-color: var(--line-strong); background: rgba(168, 85, 255, 0.1); }
+.control-tile:disabled { cursor: not-allowed; opacity: 0.48; }
+.operator-footer { min-width: 0; margin-top: 9px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+.operator-note { min-height: 34px; padding: 8px 10px; border: 1px solid rgba(155, 86, 255, 0.16); background: rgba(4, 1, 8, 0.68); color: var(--muted); font-family: var(--mono); font-size: 10px; }
+.operator-note strong { display: block; color: var(--text); font-size: 10px; }
 .up { color: var(--green) !important; }
 .down { color: var(--red) !important; }
 .info { color: var(--cyan) !important; }
@@ -289,7 +312,7 @@ h1, h2, h3, p { margin: 0; }
 }
 @media (max-width: 820px) {
   .deck { padding: 10px; }
-  .top, .ticker, .cols-2, .cols-3, .cols-4, .mini-grid, .state-matrix, .truth-grid, .command-grid, .scene-hud { grid-template-columns: 1fr; }
+  .top, .ticker, .cols-2, .cols-3, .cols-4, .mini-grid, .state-matrix, .truth-grid, .command-grid, .scene-hud, .operator-footer { grid-template-columns: 1fr; }
   .nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .nav button { height: 34px; }
   .actions { justify-content: flex-start; }
@@ -351,6 +374,24 @@ function formatRelativeTime(value?: string | null): string {
   if (diffSeconds < 60) return `${diffSeconds}s ago`;
   if (diffSeconds < 3600) return `${Math.round(diffSeconds / 60)}m ago`;
   return `${Math.round(diffSeconds / 3600)}h ago`;
+}
+
+function formatAgeSeconds(value?: number | null): string {
+  if (value == null || Number.isNaN(value)) return '--';
+  if (value < 60) return `${Math.round(value)}s`;
+  if (value < 3600) return `${Math.round(value / 60)}m`;
+  return `${Math.round(value / 3600)}h`;
+}
+
+function findOperatorProcess(status: OperatorControlStatus | null, token: string): OperatorProcessStatus | null {
+  const needle = token.toLowerCase();
+  return status?.processes.find((process) => process.name.toLowerCase().includes(needle)) ?? null;
+}
+
+function processTone(process?: OperatorProcessStatus | null): BadgeTone {
+  if (!process) return 'watch';
+  if (!process.running) return 'block';
+  return 'live';
 }
 
 function kalshiEventHour(metrics?: FilterlessKalshiMetrics | null): number | null {
@@ -1351,10 +1392,42 @@ function FilterlessLiveCockpit() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeScreen, setActiveScreen] = useState<ScreenId>('overview');
+  const [pollingPaused, setPollingPaused] = useState(false);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const [controlStatus, setControlStatus] = useState<OperatorControlStatus | null>(null);
+  const [controlError, setControlError] = useState<string | null>(null);
+  const [controlMessage, setControlMessage] = useState<string | null>(null);
   const inFlightRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const lastGeneratedAtRef = useRef<string | null>(null);
   const lastGoodSentimentRef = useRef<FilterlessSentimentMetrics>(DEFAULT_SENTIMENT_METRICS);
+
+  const fetchControlStatus = useCallback(async () => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 1800);
+    try {
+      const response = await fetch(`${OPERATOR_CONTROL_URL}/status?ts=${Date.now()}`, {
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const payload = (await response.json()) as OperatorControlStatus;
+      startTransition(() => {
+        setControlStatus(payload);
+        setControlError(null);
+      });
+    } catch (err) {
+      const isAbortError =
+        (err instanceof DOMException && err.name === 'AbortError') ||
+        (err instanceof Error && err.name === 'AbortError');
+      startTransition(() => {
+        setControlStatus(null);
+        setControlError(isAbortError ? 'launcher controls timeout' : err instanceof Error ? err.message : String(err));
+      });
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -1406,6 +1479,12 @@ function FilterlessLiveCockpit() {
     };
 
     void loadState();
+    if (pollingPaused) {
+      return () => {
+        cancelled = true;
+        abortRef.current?.abort();
+      };
+    }
     const timer = window.setInterval(loadState, REFRESH_MS);
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') void loadState();
@@ -1417,7 +1496,13 @@ function FilterlessLiveCockpit() {
       window.clearInterval(timer);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, []);
+  }, [pollingPaused, refreshNonce]);
+
+  useEffect(() => {
+    void fetchControlStatus();
+    const timer = window.setInterval(fetchControlStatus, 5000);
+    return () => window.clearInterval(timer);
+  }, [fetchControlStatus]);
 
   const effectiveStatus = computeFeedStatus(state.bot.status, state.generated_at);
   const openPositions = useMemo(() => {
@@ -1464,6 +1549,106 @@ function FilterlessLiveCockpit() {
     }
     return warnings;
   }, [effectiveStatus, state.bot.status, state.bot.warnings, state.generated_at]);
+  const botProcess = findOperatorProcess(controlStatus, 'filterless bot');
+  const bridgeProcess = findOperatorProcess(controlStatus, 'dashboard bridge');
+  const frontendProcess = findOperatorProcess(controlStatus, 'live ui');
+  const controlOnline = Boolean(controlStatus?.ok);
+
+  const forceFeedRefresh = () => {
+    setControlMessage('Feed refresh queued');
+    setRefreshNonce((value) => value + 1);
+    void fetchControlStatus();
+  };
+
+  const copyOperatorSnapshot = async () => {
+    const snapshot = {
+      captured_at: new Date().toISOString(),
+      feed: {
+        status: effectiveStatus,
+        generated_at: state.generated_at,
+        error,
+        warnings: feedWarnings,
+      },
+      bot: {
+        status: state.bot.status,
+        session: state.bot.session,
+        price: state.bot.price,
+        last_heartbeat_time: state.bot.last_heartbeat_time,
+        last_bar_time: state.bot.last_bar_time,
+        position_sync_status: state.bot.position_sync_status,
+        daily_pnl: state.bot.risk.daily_pnl,
+        circuit_tripped: state.bot.risk.circuit_tripped,
+      },
+      exposure: {
+        open_positions: openPositions,
+        total_lots: totalLots,
+        total_open_pnl: totalOpenPnl,
+      },
+      manifold: {
+        regime: features.regime,
+        pressure30: features.pressure30,
+        fold_depth: features.foldDepth,
+        risk_mult: features.riskMult,
+        no_trade: features.noTrade,
+      },
+      kalshi: {
+        healthy: kalshi?.healthy,
+        event_ticker: kalshi?.event_ticker,
+        status_reason: kalshi?.status_reason,
+        probability_60m: kalshi?.probability_60m,
+      },
+      truth: {
+        healthy: sentiment.healthy,
+        label: sentiment.sentiment_label,
+        score: sentiment.sentiment_score,
+        trigger_reason: sentiment.trigger_reason,
+        last_error: sentiment.last_error,
+      },
+      recent_events: state.events.slice(0, 12),
+    };
+    const text = JSON.stringify(snapshot, null, 2);
+    try {
+      await navigator.clipboard.writeText(text);
+      setControlMessage('Snapshot copied');
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setControlMessage('Snapshot copied');
+    }
+  };
+
+  const sendOperatorCommand = async (action: OperatorCommandAction, label: string) => {
+    if (!controlOnline) {
+      setControlMessage('Launcher controls offline');
+      return;
+    }
+    if (action === 'restart_bot' && openPositions.length > 0) {
+      const ok = window.confirm('Restart the bot while a broker position is active? Exits are broker-side, but the runtime loop will reconnect.');
+      if (!ok) return;
+    }
+    try {
+      setControlMessage(`${label} requested`);
+      const response = await fetch(`${OPERATOR_CONTROL_URL}/command`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      setControlMessage(`${label} queued`);
+      window.setTimeout(() => {
+        void fetchControlStatus();
+        setRefreshNonce((value) => value + 1);
+      }, 1000);
+    } catch (err) {
+      setControlMessage(`${label} failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
 
   const logicRows = [
     ['FEED', `status ${effectiveStatus}, heartbeat ${formatRelativeTime(state.bot.last_heartbeat_time)}`, effectiveStatus === 'online' ? 'pass' : 'block'],
@@ -1779,34 +1964,65 @@ function FilterlessLiveCockpit() {
           </div>
         </Panel>
       ) : null}
-      <Panel title="Operator Controls" subtitle="High-level runtime controls and status lanes." badge={<Badge tone="live">operator</Badge>} className="mt-panel">
+      <Panel title="Operator Controls" subtitle="Live runtime actions for the bot loop, bridge, UI feed, and operator journal." badge={<Badge tone={controlOnline ? 'live' : 'watch'}>{controlOnline ? 'control online' : 'local only'}</Badge>} className="mt-panel">
         <div className="panel-body">
           <div className="command-grid">
-            <button className="command-tile control-tile" type="button">
-              <strong className="truncate">Freeze Entries</strong>
-              <small className="truncate">keep exits live</small>
-              <Badge tone="watch">ready</Badge>
+            <button className="command-tile control-tile" type="button" onClick={forceFeedRefresh}>
+              <strong className="truncate">Refresh Feed</strong>
+              <small className="truncate">{error ? 'endpoint check' : formatRelativeTime(state.generated_at)}</small>
+              <Badge tone={error ? 'block' : statusBadge(effectiveStatus)}>fetch</Badge>
             </button>
-            <button className="command-tile control-tile" type="button">
-              <strong className="truncate">Replay Window</strong>
-              <small className="truncate">last 180 bars</small>
-              <Badge tone="info">queued</Badge>
+            <button className="command-tile control-tile" type="button" onClick={() => setPollingPaused((value) => !value)}>
+              <strong className="truncate">{pollingPaused ? 'Resume Polling' : 'Pause Polling'}</strong>
+              <small className="truncate">{pollingPaused ? 'manual refresh only' : `${Math.round(REFRESH_MS / 1000)}s dashboard cadence`}</small>
+              <Badge tone={pollingPaused ? 'watch' : 'live'}>{pollingPaused ? 'paused' : 'live'}</Badge>
             </button>
-            <button className="command-tile control-tile" type="button">
-              <strong className="truncate">Kalshi Guard</strong>
-              <small className="truncate">book edge pass</small>
-              <Badge tone="live">online</Badge>
+            <button className="command-tile control-tile" type="button" disabled={!controlOnline} onClick={() => void sendOperatorCommand('restart_bridge', 'Bridge restart')}>
+              <strong className="truncate">Restart Bridge</strong>
+              <small className="truncate">dashboard JSON writer</small>
+              <Badge tone={processTone(bridgeProcess)}>{bridgeProcess?.running ? 'running' : controlOnline ? 'down' : 'offline'}</Badge>
             </button>
-            <button className="command-tile control-tile" type="button">
-              <strong className="truncate">Truth Exit</strong>
-              <small className="truncate">sentiment guard</small>
-              <Badge tone="watch">auto</Badge>
+            <button className="command-tile control-tile" type="button" disabled={!controlOnline} onClick={() => void sendOperatorCommand('restart_bot', 'Bot restart')}>
+              <strong className="truncate">Restart Bot</strong>
+              <small className="truncate">{openPositions.length ? `${openPositions.length} position${openPositions.length === 1 ? '' : 's'} active` : 'flat runtime'}</small>
+              <Badge tone={openPositions.length ? 'watch' : processTone(botProcess)}>{botProcess?.running ? 'loop' : controlOnline ? 'down' : 'offline'}</Badge>
             </button>
-            <button className="command-tile control-tile" type="button">
-              <strong className="truncate">Journal Pin</strong>
-              <small className="truncate">state snapshot</small>
-              <Badge tone="info">armed</Badge>
+            <button className="command-tile control-tile" type="button" disabled={!controlOnline} onClick={() => void sendOperatorCommand('restart_frontend', 'UI restart')}>
+              <strong className="truncate">Restart UI</strong>
+              <small className="truncate">live cockpit server</small>
+              <Badge tone={processTone(frontendProcess)}>{frontendProcess?.running ? 'serving' : controlOnline ? 'down' : 'offline'}</Badge>
             </button>
+            <button className="command-tile control-tile" type="button" onClick={() => setActiveScreen('kalshi')}>
+              <strong className="truncate">Kalshi Gate</strong>
+              <small className="truncate">{kalshi?.status_reason || kalshi?.event_ticker || 'no ladder'}</small>
+              <Badge tone={kalshi?.healthy ? 'live' : 'watch'}>{kalshi?.healthy ? 'online' : 'review'}</Badge>
+            </button>
+            <button className="command-tile control-tile" type="button" onClick={() => setActiveScreen('news')}>
+              <strong className="truncate">Truth Monitor</strong>
+              <small className="truncate">{sentiment.trigger_reason || sentiment.sentiment_label || 'neutral'}</small>
+              <Badge tone={sentiment.last_error ? 'block' : features.truthRiskWatch ? 'watch' : 'info'}>{sentiment.last_error ? 'issue' : features.truthRiskWatch ? 'watch' : 'clear'}</Badge>
+            </button>
+            <button className="command-tile control-tile" type="button" onClick={() => setActiveScreen(primaryPosition ? 'overview' : 'journal')}>
+              <strong className="truncate">Position Review</strong>
+              <small className="truncate">{primaryPosition ? `${primaryPosition.side} ${primaryPosition.size ?? '--'} @ ${formatPrice(entry)}` : 'flat journal'}</small>
+              <Badge tone={primaryPosition ? 'watch' : 'info'}>{primaryPosition ? 'active' : 'flat'}</Badge>
+            </button>
+            <button className="command-tile control-tile" type="button" onClick={() => setActiveScreen('aetherflow')}>
+              <strong className="truncate">Manifold Check</strong>
+              <small className="truncate">{features.regime}</small>
+              <Badge tone={features.noTrade ? 'block' : 'info'}>{features.noTrade ? 'lockout' : 'clear'}</Badge>
+            </button>
+            <button className="command-tile control-tile" type="button" onClick={() => void copyOperatorSnapshot()}>
+              <strong className="truncate">Copy Snapshot</strong>
+              <small className="truncate">state, risk, gates, events</small>
+              <Badge tone="info">journal</Badge>
+            </button>
+          </div>
+          <div className="operator-footer">
+            <div className="operator-note"><strong className="truncate">control</strong><span className="truncate">{controlOnline ? 'launcher API online' : controlError || 'launcher controls unavailable'}</span></div>
+            <div className="operator-note"><strong className="truncate">state file</strong><span className="truncate">{formatAgeSeconds(controlStatus?.dashboard_state_age_seconds)} old</span></div>
+            <div className="operator-note"><strong className="truncate">bot pid</strong><span className="truncate">{botProcess?.pid ?? '--'} / {botProcess?.running ? 'running' : 'stopped'}</span></div>
+            <div className="operator-note"><strong className="truncate">last action</strong><span className="truncate">{controlMessage || 'none'}</span></div>
           </div>
         </div>
       </Panel>
@@ -1859,11 +2075,11 @@ function FilterlessLiveCockpit() {
             <div className="actions">
               <span className="chip"><span className={`dot ${effectiveStatus === 'online' ? '' : 'down-dot'}`} />live</span>
               <span className="chip">{new Date().toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour12: false })} ET</span>
-              <button className="command primary" type="button" onClick={() => setActiveScreen('command')}>Arm Guard</button>
+              <button className="command primary" type="button" onClick={() => setActiveScreen('command')}>Command Center</button>
             </div>
           </header>
 
-          {error ? <div className="notice">Dashboard feed error: {error}</div> : null}
+          {error ? <div className="notice">Dashboard feed endpoint error: {error}</div> : null}
           {loading ? <div className="notice">Loading filterless dashboard state...</div> : null}
 
           <section className="ticker" aria-label="Session metrics">


### PR DESCRIPTION
## Summary
- replace the mock operator buttons with useful live controls for feed refresh, polling pause/resume, bridge restart, bot restart, UI restart, monitor review, position review, manifold review, and operator snapshot copy
- add a localhost launcher control API on `127.0.0.1:3011` so the live UI can queue real process restarts for the managed bot, dashboard bridge, and UI server
- clarify the dashboard feed notice as an endpoint fetch error rather than a stale market-feed state

## Why
The previous buttons looked like runtime controls but did not map to the actual bot/launcher functions. The new controls reflect the runtime pieces the live bot actually depends on: the bot loop, bridge JSON writer, Vite/static UI server, current exposure, Kalshi gate, Truth monitor, manifold lockout, and state snapshots.

## Validation
- `npm run build`
- `python -m py_compile launch_filterless_workspace.py`
- `cmd /v:on /c "call LaunchFilterlessWorkspace.bat --help"`
- operator control API smoke test with `/status` and `/command`
- `git diff --check`
- `graphify update .`

## Notes
The bot restart button asks for confirmation when a broker position is active. The UI does not imply that Truth Social or the command center can flatten broker positions.