### PR TITLE
[codex] Keep live dashboard endpoint online

### DIFF
--- a/julie001.py
+++ b/julie001.py
@@ -716,6 +716,16 @@ class _NoOpDirectionalLossBlocker(_NoOpStatefulRuntime):
         return None
 
 
+class _NoOpCascadeLossBlocker(_NoOpStatefulRuntime):
+    def record_trade_result(self, *_args, **_kwargs):
+        return None
+
+
+class _NoOpAntiFlipBlocker(_NoOpStatefulRuntime):
+    def record_trade_close(self, *_args, **_kwargs):
+        return None
+
+
 class _NoOpImpulseFilter(_NoOpStatefulRuntime):
     def __init__(self, *args, **kwargs):
         self.wick_ratio_threshold = 0.0
@@ -7826,7 +7836,6 @@ async def run_bot():
         logging.warning(
             "[CascadeBlocker] import failed (%s) — using no-op", _cascade_exc
         )
-        from cascade_loss_blocker import _NoOpCascadeLossBlocker
         cascade_loss_blocker = _NoOpCascadeLossBlocker()
 
     # Anti-flip circuit breaker — when a stop-out on one side is followed
@@ -7843,7 +7852,6 @@ async def run_bot():
         logging.warning(
             "[AntiFlipBlocker] import failed (%s) — using no-op", _antiflip_exc
         )
-        from anti_flip_blocker import _NoOpAntiFlipBlocker
         anti_flip_blocker = _NoOpAntiFlipBlocker()
 
     impulse_filter = ImpulseFilterCls(lookback=20, impulse_multiplier=2.5)

--- a/launch_filterless_workspace.py
+++ b/launch_filterless_workspace.py
@@ -645,6 +645,19 @@ def restart_managed_process(entry: dict[str, object]) -> None:
     entry["handle"] = handle
     entry["launched_at"] = time.time()
     entry["restart_count"] = int(entry.get("restart_count") or 0) + 1
+    entry["restart_exhausted"] = False
+    entry["failure_reason"] = None
+
+
+def is_frontend_process_name(name: str) -> bool:
+    normalized = name.lower()
+    return "live ui" in normalized or "dev server" in normalized or "static server" in normalized
+
+
+def mark_restart_exhausted(entry: dict[str, object], reason: str) -> None:
+    entry["restart_exhausted"] = True
+    entry["failure_reason"] = reason
+    log_workspace_status(reason)
 
 
 def operator_process_snapshot(entry: dict[str, object]) -> dict[str, object]:
@@ -665,6 +678,8 @@ def operator_process_snapshot(entry: dict[str, object]) -> dict[str, object]:
         "running": running,
         "exit_code": exit_code,
         "restart_count": int(entry.get("restart_count") or 0),
+        "restart_exhausted": bool(entry.get("restart_exhausted")),
+        "failure_reason": entry.get("failure_reason"),
         "watch_path": str(watch_path) if isinstance(watch_path, Path) else None,
         "watch_age_seconds": round(watch_age, 1) if watch_age is not None else None,
     }
@@ -976,6 +991,8 @@ def main() -> int:
                 process = entry.get("process")
                 if not isinstance(process, subprocess.Popen):
                     continue
+                if bool(entry.get("restart_exhausted")):
+                    continue
                 exit_code = process.poll()
                 if exit_code is not None:
                     restart_count = int(entry.get("restart_count") or 0)
@@ -985,8 +1002,16 @@ def main() -> int:
                         record_managed_processes(managed)
                         restarted = True
                         break
-                    print(f"{name} exited with code {exit_code}. Restart limit reached; stopping remaining processes...")
-                    return exit_code
+                    if is_frontend_process_name(name):
+                        print(f"{name} exited with code {exit_code}. Restart limit reached; stopping remaining processes...")
+                        return exit_code
+                    reason = (
+                        f"{name} exited with code {exit_code}. Restart limit reached; "
+                        "keeping dashboard UI online for diagnostics."
+                    )
+                    print(reason)
+                    mark_restart_exhausted(entry, reason)
+                    record_managed_processes(managed)
             if restarted:
                 continue
 
@@ -1001,6 +1026,8 @@ def main() -> int:
                 launched_at = float(entry.get("launched_at") or now)
                 if not isinstance(watch_path, Path) or stale_seconds in (None, 0):
                     continue
+                if bool(entry.get("restart_exhausted")):
+                    continue
                 stale_limit = float(stale_seconds)
                 if now - launched_at < stale_limit:
                     continue
@@ -1009,8 +1036,14 @@ def main() -> int:
                     continue
                 restart_count = int(entry.get("restart_count") or 0)
                 if restart_count >= MAX_RESTARTS_PER_PROCESS:
-                    print(f"{name} watchdog detected stale output ({age:.0f}s) but restart limit is reached.")
-                    return 1
+                    reason = (
+                        f"{name} watchdog detected stale output ({age:.0f}s) but restart limit is reached; "
+                        "keeping dashboard UI online for diagnostics."
+                    )
+                    print(reason)
+                    mark_restart_exhausted(entry, reason)
+                    record_managed_processes(managed)
+                    continue
                 print(f"{name} watchdog detected stale output ({age:.0f}s). Restarting ({restart_count + 1}/{MAX_RESTARTS_PER_PROCESS})...")
                 restart_managed_process(entry)
                 record_managed_processes(managed)


### PR DESCRIPTION
## Summary

Fixes the dashboard feed endpoint failure mode seen when the live bot crashes during startup.

## Root Cause

The cascade/anti-flip blocker fallback path caught a missing optional blocker module, then tried to import the no-op fallback from that same missing module. That crashed the bot. The workspace launcher then treated the bot failure as fatal for the whole workspace and shut down the UI server on port 3000, which made the dashboard report a feed endpoint fetch error.

## Changes

- Adds local no-op cascade and anti-flip blocker classes in `julie001.py` so missing optional blocker modules no longer defeat the fallback.
- Updates `launch_filterless_workspace.py` so exhausted bot/bridge restarts are exposed as diagnostic status while the live dashboard UI stays online.
- Keeps full shutdown behavior for frontend failure, because the endpoint cannot be served if the UI server itself dies.

## Validation

- `python -m py_compile julie001.py launch_filterless_workspace.py launch_filterless_live.py`
- `python launch_filterless_workspace.py --help`
- `git diff --check -- julie001.py launch_filterless_workspace.py`
- `graphify update .`