### PR TITLE
[codex] Disable legacy Wesley blockers by default

### DIFF
--- a/launch_filterless_live.py
+++ b/launch_filterless_live.py
@@ -243,34 +243,17 @@ os.environ.setdefault("JULIE_RL_MIN_MFE_FRAC_FOR_TIGHTEN", "0.50")
 # shadow-only ([CM_GATE_V2] log lines still emit for observation).
 os.environ.setdefault("JULIE_KALSHI_CM_GATE_V2_ACTIVE", "1")
 
-# Cascade loss blocker — time-window same-side loss cluster veto.
-# Distinct from DirectionalLossBlocker (which counts strictly-consecutive
-# losses with no time bound). Backtest on 5,237 trades / 370 days
-# (2025 + 2026 Jan-Apr) at the default config (count=2 / window=30min /
-# cool=30min) showed:
-#     2026: +$1,133 vs baseline (PF 1.12→1.17, DD ↓$1.5k)
-#     2025: +$4,222 vs baseline (PF 1.04→1.07, DD ↓$1.1k)
-# Counterfactual confirmed the blocked set is genuinely net-losing
-# (~11% of trades blocked, blocked PnL = exact -lift). Activated by
-# default as of 2026-04-23 after backtest review. Override with
-#     export JULIE_CASCADE_BLOCKER_ACTIVE=0
-# to disable, or change COUNT/WINDOW_MIN/COOLDOWN_MIN to tune. See
-# scripts/backtest_consec_loss_blocker.py for the 24-config sweep.
-os.environ.setdefault("JULIE_CASCADE_BLOCKER_ACTIVE", "1")
+# Legacy same-side loss-cluster blocker from the Wesley/Claude branch.
+# Keep the module importable, but leave it disabled by default until it is
+# revalidated in this workspace's current backtest harness.
+os.environ.setdefault("JULIE_CASCADE_BLOCKER_ACTIVE", "0")
 os.environ.setdefault("JULIE_CASCADE_BLOCKER_COUNT", "2")
 os.environ.setdefault("JULIE_CASCADE_BLOCKER_WINDOW_MIN", "30")
 os.environ.setdefault("JULIE_CASCADE_BLOCKER_COOLDOWN_MIN", "30")
 
-# Anti-flip blocker — when a SHORT stops out and a LONG signal fires near
-# the stop price within a short window (or vice versa), reject the new
-# signal. Catches the DE3 "flip at the top / flip at the bottom" pattern
-# observed on 2026-04-23 (SHORT stopped at 7172.50, LONG flipped at 7171.75
-# sixty seconds later, then rode into a 64pt dump and lost). Parameter
-# sweep over 2025 full year + 2026 Jan-Apr at window=30min max_dist=8pt:
-#     2026: +$235  ·  2025: +$2,944  ·  combined +$3,179 lift
-# Active by default as of 2026-04-23 late. Override with
-#     export JULIE_ANTI_FLIP_BLOCKER_ACTIVE=0
-os.environ.setdefault("JULIE_ANTI_FLIP_BLOCKER_ACTIVE", "1")
+# Legacy opposite-side stop-flip blocker from the Wesley/Claude branch.
+# Disabled by default for the same reason as the cascade blocker.
+os.environ.setdefault("JULIE_ANTI_FLIP_BLOCKER_ACTIVE", "0")
 os.environ.setdefault("JULIE_ANTI_FLIP_WINDOW_MIN", "30")
 os.environ.setdefault("JULIE_ANTI_FLIP_MAX_DIST_PTS", "8.0")
 


### PR DESCRIPTION
## Summary

Disables the Wesley/Claude-origin cascade and anti-flip blocker layers by default in the live launcher.

## Why

Git history shows the blocker modules, standalone sweep scripts, and active-by-default launcher flags came from commit `79a1aac` authored by `wesleyphin <wmphin@gmail.com>` and co-authored by Claude. These layers were not validated through this workspace's current backtest/runtime harness, so they should not affect live behavior unless explicitly opted in.

## Changes

- Sets `JULIE_CASCADE_BLOCKER_ACTIVE` default to `0`.
- Sets `JULIE_ANTI_FLIP_BLOCKER_ACTIVE` default to `0`.
- Leaves parameter defaults and modules intact so explicit opt-in remains possible and imports remain stable.

## Validation

- `python -m py_compile launch_filterless_live.py julie001.py launch_filterless_workspace.py`
- `graphify update .`